### PR TITLE
feat: HDMA, xBRZ upscale, fullscreen + title-sword fix + Windows cross-compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,9 @@ ctx.c
 build/
 .vscode/
 rom_data/
+
+# Copyrighted ROM, extracted assets, and per-user runtime state.
+# These must NOT be committed to the public repository.
+baserom.gba
+*.sav
+run/

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ rom_data/
 baserom.gba
 *.sav
 run/
+config.json
+release/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,34 @@ Discord: <https://discord.zelda64.dev>
 
 Documentation: <https://zeldaret.github.io/tmc>
 
+## PC port (work in progress)
+
+This fork includes an experimental PC build target (`tmc_pc`) that runs the
+decompiled game natively via SDL3 + a software PPU (`libs/ViruaPPU`). The port
+is **WIP** — many rendering and gameplay paths are still rough.
+
+Tested platforms:
+
+* Linux (Wayland preferred, X11 fallback)
+* Windows via MinGW static link
+
+macOS may build (the xmake config sets up the toolchain) but is not regularly
+tested.
+
+Build with `xmake build tmc_pc`; the binary lands in `build/pc/`. Run it from
+that directory so it finds the extracted assets in `build/pc/assets/`.
+
+### Controls
+
+| Action               | Keyboard            | Gamepad                |
+|----------------------|---------------------|------------------------|
+| Fast-forward (hold)  | Tab                 | Right trigger          |
+| Toggle fullscreen    | F11 / Alt+Enter     | —                      |
+| Cycle upscaler       | F12                 | —                      |
+
+Default upscaler is nearest-neighbor (sharp pixels). F12 cycles through
+xBRZ 4× and linear modes.
+
 ## Installation
 
 To set up the repository, see [INSTALL.md](INSTALL.md).

--- a/include/gba/macro.h
+++ b/include/gba/macro.h
@@ -10,6 +10,7 @@
  * emulated memory arrays via port_resolve_addr().
  */
 #include "port_gba_mem.h"
+#include "port_hdma.h"
 #include <string.h>
 
 /* ---- DmaSet: raw DMA register write emulation ---- */
@@ -27,6 +28,15 @@ static inline void port_DmaTransfer(const void* src_raw, uintptr_t dest_raw, u32
     void* dest = port_resolve_addr(dest_raw);
     if (!src || !dest)
         return;
+
+    /*
+     * HBlank-triggered DMA: register with the per-scanline simulator instead
+     * of doing the transfer immediately. Drives the iris/circle WIN0H effect.
+     */
+    if ((cnt & 0x2000) != 0) {
+        port_hdma_register(0, src, dest, cnt, (u16)units);
+        return;
+    }
 
     if (srcFixed) {
         /* Fill mode */

--- a/port/patches/viruappu-hdma-hook.patch
+++ b/port/patches/viruappu-hdma-hook.patch
@@ -1,0 +1,41 @@
+diff --git a/include/cpu/mode1.h b/include/cpu/mode1.h
+index 77abf82..8e91619 100644
+--- a/include/cpu/mode1.h
++++ b/include/cpu/mode1.h
+@@ -9,6 +9,9 @@
+ extern "C" {
+ #endif
+ 
++typedef void (*virtuappu_mode1_pre_line_fn)(int line);
++extern virtuappu_mode1_pre_line_fn virtuappu_mode1_pre_line_callback;
++
+ enum {
+     MODE1_GBA_WIDTH = 240,
+     MODE1_GBA_HEIGHT = 160,
+diff --git a/src/mode1.c b/src/mode1.c
+index c4bfe70..fb6cbca 100644
+--- a/src/mode1.c
++++ b/src/mode1.c
+@@ -1,9 +1,12 @@
+ #include "cpu/mode1.h"
+ 
++#include <stddef.h>
+ #include <string.h>
+ 
+ #include "virtuappu.h"
+ 
++virtuappu_mode1_pre_line_fn virtuappu_mode1_pre_line_callback = NULL;
++
+ typedef struct Mode1TilemapEntry {
+     uint16_t raw;
+ } Mode1TilemapEntry;
+@@ -695,6 +698,9 @@ void virtuappu_mode1_render_frame(const PPUMemory *ppu)
+     }
+ 
+     for (line = 0; line < MODE1_GBA_HEIGHT; ++line) {
++        if (virtuappu_mode1_pre_line_callback != NULL) {
++            virtuappu_mode1_pre_line_callback(line);
++        }
+         uint32_t bg_layers[MODE1_GBA_BG_COUNT][MODE1_GBA_WIDTH];
+         uint8_t bg_priority[MODE1_GBA_BG_COUNT][MODE1_GBA_WIDTH];
+         uint32_t obj_layer[MODE1_GBA_WIDTH];

--- a/port/patches/viruappu-hdma-hook.patch
+++ b/port/patches/viruappu-hdma-hook.patch
@@ -5,7 +5,7 @@ index 77abf82..8e91619 100644
 @@ -9,6 +9,9 @@
  extern "C" {
  #endif
- 
+
 +typedef void (*virtuappu_mode1_pre_line_fn)(int line);
 +extern virtuappu_mode1_pre_line_fn virtuappu_mode1_pre_line_callback;
 +
@@ -18,12 +18,12 @@ index c4bfe70..fb6cbca 100644
 +++ b/src/mode1.c
 @@ -1,9 +1,12 @@
  #include "cpu/mode1.h"
- 
+
 +#include <stddef.h>
  #include <string.h>
- 
+
  #include "virtuappu.h"
- 
+
 +virtuappu_mode1_pre_line_fn virtuappu_mode1_pre_line_callback = NULL;
 +
  typedef struct Mode1TilemapEntry {
@@ -31,7 +31,21 @@ index c4bfe70..fb6cbca 100644
  } Mode1TilemapEntry;
 @@ -695,6 +698,9 @@ void virtuappu_mode1_render_frame(const PPUMemory *ppu)
      }
- 
+
+     for (line = 0; line < MODE1_GBA_HEIGHT; ++line) {
++        if (virtuappu_mode1_pre_line_callback != NULL) {
++            virtuappu_mode1_pre_line_callback(line);
++        }
+         uint32_t bg_layers[MODE1_GBA_BG_COUNT][MODE1_GBA_WIDTH];
+         uint8_t bg_priority[MODE1_GBA_BG_COUNT][MODE1_GBA_WIDTH];
+         uint32_t obj_layer[MODE1_GBA_WIDTH];
+diff --git a/src/mode2.c b/src/mode2.c
+index 0b6daf7..189c580 100644
+--- a/src/mode2.c
++++ b/src/mode2.c
+@@ -20,6 +20,9 @@ void virtuappu_mode2_render_frame(const PPUMemory *ppu)
+     }
+
      for (line = 0; line < MODE1_GBA_HEIGHT; ++line) {
 +        if (virtuappu_mode1_pre_line_callback != NULL) {
 +            virtuappu_mode1_pre_line_callback(line);

--- a/port/patches/viruappu-mosaic.patch
+++ b/port/patches/viruappu-mosaic.patch
@@ -22,12 +22,13 @@ index ccccccc..ddddddd 100644
      bool bpp8 = ((bgcnt >> 7u) & 1u) != 0u;
      uint32_t screen_base = (uint32_t)((bgcnt >> 8u) & 0x1Fu) * 0x800u;
      uint16_t size_flag = (uint16_t)((bgcnt >> 14u) & 3u);
-@@ -300,13 +301,18 @@
+@@ -300,13 +301,19 @@
      int map_height_tiles = (size_flag & 2u) ? 64 : 32;
      int scroll_x = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0HOFS + bg_index * 4)) & 0x1FF;
      int scroll_y = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0VOFS + bg_index * 4)) & 0x1FF;
 -    int src_y = (line + scroll_y) % (map_height_tiles * 8);
 +    uint16_t mosaic_reg = virtuappu_mode1_io_read16(MODE1_IO_MOSAIC);
++    if (getenv("TMC_NO_MOSAIC")) mosaic_on = false;
 +    int mosaic_h = mosaic_on ? (int)((mosaic_reg & 0x0Fu) + 1u) : 1;
 +    int mosaic_v = mosaic_on ? (int)(((mosaic_reg >> 4u) & 0x0Fu) + 1u) : 1;
 +    int eff_line = (line / mosaic_v) * mosaic_v;
@@ -43,7 +44,7 @@ index ccccccc..ddddddd 100644
          int tile_col = src_x / 8;
          int pixel_x = src_x % 8;
          int screen_block_x = tile_col / 32;
-@@ -410,6 +416,7 @@
+@@ -410,6 +417,7 @@
      bgcnt = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0CNT + bg_index * 2));
      priority = (uint8_t)(bgcnt & 3u);
      char_base = (uint32_t)((bgcnt >> 2u) & 3u) * 0x4000u;
@@ -51,7 +52,7 @@ index ccccccc..ddddddd 100644
      map_base = (uint32_t)((bgcnt >> 8u) & 0x1Fu) * 0x800u;
      wrap = ((bgcnt >> 13u) & 1u) != 0u;
      map_tiles = k_affine_tiles[(bgcnt >> 14u) & 3u];
-@@ -429,12 +436,18 @@
+@@ -429,12 +437,19 @@
          ref_y |= (int32_t)0xF8000000;
      }
  
@@ -63,6 +64,7 @@ index ccccccc..ddddddd 100644
 -        int32_t tex_y_fp = start_y + (int32_t)pc * x;
 +    {
 +        uint16_t mosaic_reg = virtuappu_mode1_io_read16(MODE1_IO_MOSAIC);
++        if (getenv("TMC_NO_MOSAIC")) mosaic_on = false;
 +        int mosaic_h = mosaic_on ? (int)((mosaic_reg & 0x0Fu) + 1u) : 1;
 +        int mosaic_v = mosaic_on ? (int)(((mosaic_reg >> 4u) & 0x0Fu) + 1u) : 1;
 +        int eff_line = (line / mosaic_v) * mosaic_v;
@@ -76,7 +78,7 @@ index ccccccc..ddddddd 100644
          int32_t src_x = tex_x_fp >> 8;
          int32_t src_y = tex_y_fp >> 8;
          int tile_col;
-@@ -470,6 +483,7 @@
+@@ -470,6 +485,7 @@
          rgb555 = mode1_memory.bg_palette[color_index];
          line_buffer[x] = virtuappu_mode1_rgb555_to_abgr8888(rgb555);
          priority_buffer[x] = priority;

--- a/port/patches/viruappu-mosaic.patch
+++ b/port/patches/viruappu-mosaic.patch
@@ -1,0 +1,86 @@
+diff --git a/include/cpu/mode1.h b/include/cpu/mode1.h
+index aaaaaaa..bbbbbbb 100644
+--- a/include/cpu/mode1.h
++++ b/include/cpu/mode1.h
+@@ -54,6 +54,7 @@
+     MODE1_IO_WIN1V = 0x46,
+     MODE1_IO_WININ = 0x48,
+     MODE1_IO_WINOUT = 0x4A,
++    MODE1_IO_MOSAIC = 0x4C,
+     MODE1_IO_BLDCNT = 0x50,
+     MODE1_IO_BLDALPHA = 0x52,
+     MODE1_IO_BLDY = 0x54
+diff --git a/src/mode1.c b/src/mode1.c
+index ccccccc..ddddddd 100644
+--- a/src/mode1.c
++++ b/src/mode1.c
+@@ -293,6 +293,7 @@
+     uint16_t bgcnt = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0CNT + bg_index * 2));
+     uint8_t priority = (uint8_t)(bgcnt & 3u);
+     uint32_t char_base = (uint32_t)((bgcnt >> 2u) & 3u) * 0x4000u;
++    bool mosaic_on = ((bgcnt >> 6u) & 1u) != 0u;
+     bool bpp8 = ((bgcnt >> 7u) & 1u) != 0u;
+     uint32_t screen_base = (uint32_t)((bgcnt >> 8u) & 0x1Fu) * 0x800u;
+     uint16_t size_flag = (uint16_t)((bgcnt >> 14u) & 3u);
+@@ -300,13 +301,18 @@
+     int map_height_tiles = (size_flag & 2u) ? 64 : 32;
+     int scroll_x = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0HOFS + bg_index * 4)) & 0x1FF;
+     int scroll_y = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0VOFS + bg_index * 4)) & 0x1FF;
+-    int src_y = (line + scroll_y) % (map_height_tiles * 8);
++    uint16_t mosaic_reg = virtuappu_mode1_io_read16(MODE1_IO_MOSAIC);
++    int mosaic_h = mosaic_on ? (int)((mosaic_reg & 0x0Fu) + 1u) : 1;
++    int mosaic_v = mosaic_on ? (int)(((mosaic_reg >> 4u) & 0x0Fu) + 1u) : 1;
++    int eff_line = (line / mosaic_v) * mosaic_v;
++    int src_y = (eff_line + scroll_y) % (map_height_tiles * 8);
+     int tile_row = src_y / 8;
+     int pixel_y = src_y % 8;
+     int x;
+ 
+     for (x = 0; x < MODE1_GBA_WIDTH; ++x) {
+-        int src_x = (x + scroll_x) % (map_width_tiles * 8);
++        int eff_x = (x / mosaic_h) * mosaic_h;
++        int src_x = (eff_x + scroll_x) % (map_width_tiles * 8);
+         int tile_col = src_x / 8;
+         int pixel_x = src_x % 8;
+         int screen_block_x = tile_col / 32;
+@@ -410,6 +416,7 @@
+     bgcnt = virtuappu_mode1_io_read16((uint16_t)(MODE1_IO_BG0CNT + bg_index * 2));
+     priority = (uint8_t)(bgcnt & 3u);
+     char_base = (uint32_t)((bgcnt >> 2u) & 3u) * 0x4000u;
++    bool mosaic_on = ((bgcnt >> 6u) & 1u) != 0u;
+     map_base = (uint32_t)((bgcnt >> 8u) & 0x1Fu) * 0x800u;
+     wrap = ((bgcnt >> 13u) & 1u) != 0u;
+     map_tiles = k_affine_tiles[(bgcnt >> 14u) & 3u];
+@@ -429,12 +436,18 @@
+         ref_y |= (int32_t)0xF8000000;
+     }
+ 
+-    start_x = ref_x + (int32_t)pb * line;
+-    start_y = ref_y + (int32_t)pd * line;
+-
+-    for (x = 0; x < MODE1_GBA_WIDTH; ++x) {
+-        int32_t tex_x_fp = start_x + (int32_t)pa * x;
+-        int32_t tex_y_fp = start_y + (int32_t)pc * x;
++    {
++        uint16_t mosaic_reg = virtuappu_mode1_io_read16(MODE1_IO_MOSAIC);
++        int mosaic_h = mosaic_on ? (int)((mosaic_reg & 0x0Fu) + 1u) : 1;
++        int mosaic_v = mosaic_on ? (int)(((mosaic_reg >> 4u) & 0x0Fu) + 1u) : 1;
++        int eff_line = (line / mosaic_v) * mosaic_v;
++        start_x = ref_x + (int32_t)pb * eff_line;
++        start_y = ref_y + (int32_t)pd * eff_line;
++
++        for (x = 0; x < MODE1_GBA_WIDTH; ++x) {
++            int eff_x = (x / mosaic_h) * mosaic_h;
++            int32_t tex_x_fp = start_x + (int32_t)pa * eff_x;
++            int32_t tex_y_fp = start_y + (int32_t)pc * eff_x;
+         int32_t src_x = tex_x_fp >> 8;
+         int32_t src_y = tex_y_fp >> 8;
+         int tile_col;
+@@ -470,6 +483,7 @@
+         rgb555 = mode1_memory.bg_palette[color_index];
+         line_buffer[x] = virtuappu_mode1_rgb555_to_abgr8888(rgb555);
+         priority_buffer[x] = priority;
++        }
+     }
+ }
+ 

--- a/port/port_bios.c
+++ b/port/port_bios.c
@@ -14,6 +14,7 @@
 #include <math.h>
 
 static bool gQuitRequested = false;
+static bool sFastForward = false;
 static int sFrameNum = 0;
 
 typedef struct {
@@ -83,6 +84,14 @@ static void Port_PumpEvents(void) {
                 Port_PPU_ToggleSmoothing();
                 continue;
             }
+            if (e.key.key == SDLK_TAB) {
+                sFastForward = true;
+                continue;
+            }
+        }
+        if (e.type == SDL_EVENT_KEY_UP && e.key.key == SDLK_TAB) {
+            sFastForward = false;
+            continue;
         }
         Port_Config_HandleEvent(&e);
     }
@@ -99,7 +108,9 @@ void VBlankIntrWait(void) {
     Port_PPU_PresentFrame();
     port_hdma_vblank_reset();
 
-    while (SDL_GetTicksNS() - lastFrameNs < Port_Config_FrameTimeNs()) {
+    if (!sFastForward) {
+        while (SDL_GetTicksNS() - lastFrameNs < Port_Config_FrameTimeNs()) {
+        }
     }
 
     nowNs = SDL_GetTicksNS();
@@ -122,8 +133,6 @@ void VBlankIntrWait(void) {
         sFpsWindowStartNs = nowNs;
         sFpsFrameCount = 0;
     }
-
-
 
     if (gQuitRequested) {
         exit(0);

--- a/port/port_bios.c
+++ b/port/port_bios.c
@@ -93,6 +93,11 @@ static void Port_PumpEvents(void) {
             sFastForward = false;
             continue;
         }
+        if (e.type == SDL_EVENT_GAMEPAD_AXIS_MOTION &&
+            e.gaxis.axis == SDL_GAMEPAD_AXIS_RIGHT_TRIGGER) {
+            sFastForward = e.gaxis.value > 16384;
+            continue;
+        }
         Port_Config_HandleEvent(&e);
     }
 }

--- a/port/port_bios.c
+++ b/port/port_bios.c
@@ -2,6 +2,7 @@
 #include "main.h"
 #include "port_audio.h"
 #include "port_gba_mem.h"
+#include "port_hdma.h"
 #include "port_ppu.h"
 #include "port_runtime_config.h"
 #include "port_types.h"
@@ -70,9 +71,20 @@ static void Port_PumpEvents(void) {
     while (SDL_PollEvent(&e)) {
         if (e.type == SDL_EVENT_QUIT) {
             gQuitRequested = true;
-        } else {
-            Port_Config_HandleEvent(&e);
+            continue;
         }
+        if (e.type == SDL_EVENT_KEY_DOWN && !e.key.repeat) {
+            bool altHeld = (e.key.mod & SDL_KMOD_ALT) != 0;
+            if (e.key.key == SDLK_F11 || (e.key.key == SDLK_RETURN && altHeld)) {
+                Port_PPU_ToggleFullscreen();
+                continue;
+            }
+            if (e.key.key == SDLK_F12) {
+                Port_PPU_ToggleSmoothing();
+                continue;
+            }
+        }
+        Port_Config_HandleEvent(&e);
     }
 }
 
@@ -85,6 +97,7 @@ void VBlankIntrWait(void) {
     u64 nowNs;
 
     Port_PPU_PresentFrame();
+    port_hdma_vblank_reset();
 
     while (SDL_GetTicksNS() - lastFrameNs < 16666667 ) {
     }
@@ -291,13 +304,20 @@ void BgAffineSet(struct BgAffineSrcData* src, struct BgAffineDstData* dst, s32 c
 
 /* ObjAffineSet (SWI 0x0F)
  *
- * Computes 2x2 affine matrices (pa, pb, pc, pd) from rotation+scale
- * parameters and writes them at `offset`-byte intervals.
+ * GBA BIOS computes the *inverse* texture-mapping matrix: hardware applies
+ * pa/pb/pc/pd to screen-relative coordinates to produce texture coordinates.
+ * For a visible scale of sx, the matrix uses 1/sx — so doubling sx halves
+ * the sampled-texture step per screen pixel and the sprite *grows*.
  *
- * When used with OAM (offset=8), each parameter goes into the
- * affineParam field of consecutive OAM entries (4 entries per matrix).
+ *   pa =  cos(θ) / sx
+ *   pb = -sin(θ) / sy
+ *   pc =  sin(θ) / sx
+ *   pd =  cos(θ) / sy
  *
- * GBA BIOS writes ONE s16 per destination, not 4 consecutive.
+ * Inputs sx/sy are 8.8 fixed point (0x100 = 1.0). Output pa/pb/pc/pd are
+ * also 8.8 fixed point. Each is written as one s16 at `offset`-byte
+ * intervals — for OAM (offset=8), that puts the four values in the
+ * affineParam field of 4 consecutive OAM entries.
  */
 void ObjAffineSet(struct ObjAffineSrcData* src, void* dst, s32 count, s32 offset) {
     u8* d = (u8*)dst;
@@ -305,26 +325,36 @@ void ObjAffineSet(struct ObjAffineSrcData* src, void* dst, s32 count, s32 offset
         s32 sx = src[i].xScale;
         s32 sy = src[i].yScale;
         u16 theta = src[i].rotation;
+        double angle;
+        double cosA;
+        double sinA;
+        double sxF;
+        double syF;
+        s16 pa;
+        s16 pb;
+        s16 pc;
+        s16 pd;
+
+        if (sx == 0) sx = 1;
+        if (sy == 0) sy = 1;
 
         /* GBA angle (0-0xFFFF = 0-360°) → radians */
-        double angle = (double)theta * 3.14159265358979323846 * 2.0 / 65536.0;
-        double cosA = cos(angle);
-        double sinA = sin(angle);
+        angle = (double)theta * 3.14159265358979323846 * 2.0 / 65536.0;
+        cosA = cos(angle);
+        sinA = sin(angle);
+        sxF = (double)sx / 256.0;
+        syF = (double)sy / 256.0;
 
-        /* sx, sy are 8.8 fixed point; multiply by cos/sin (float) → 8.8 result */
-        s16 pa = (s16)(sx * cosA);
-        s16 pb = (s16)(-sx * sinA);
-        s16 pc = (s16)(sy * sinA);
-        s16 pd = (s16)(sy * cosA);
+        pa = (s16)( cosA / sxF * 256.0);
+        pb = (s16)(-sinA / syF * 256.0);
+        pc = (s16)( sinA / sxF * 256.0);
+        pd = (s16)( cosA / syF * 256.0);
 
-        /* Write ONE s16 per destination, spaced by `offset` bytes.
-         * For OAM (offset=8), this writes to the affineParam field
-         * of 4 consecutive OAM entries without touching other fields. */
         *(s16*)(d + 0 * offset) = pa;
         *(s16*)(d + 1 * offset) = pb;
         *(s16*)(d + 2 * offset) = pc;
         *(s16*)(d + 3 * offset) = pd;
 
-        d += 4 * offset; /* advance to start of next matrix */
+        d += 4 * offset;
     }
 }

--- a/port/port_bios.c
+++ b/port/port_bios.c
@@ -99,7 +99,7 @@ void VBlankIntrWait(void) {
     Port_PPU_PresentFrame();
     port_hdma_vblank_reset();
 
-    while (SDL_GetTicksNS() - lastFrameNs < 16666667 ) {
+    while (SDL_GetTicksNS() - lastFrameNs < Port_Config_FrameTimeNs()) {
     }
 
     nowNs = SDL_GetTicksNS();

--- a/port/port_draw.c
+++ b/port/port_draw.c
@@ -178,14 +178,6 @@ void ram_UpdateEntities(u32 mode) {
         Entity* entity = list->first;
 
         while (entity != NULL && entity != (Entity*)list) {
-#ifdef PC_PORT
-            if (mode == 1) {
-                fprintf(stderr,
-                        "[MANAGER-LOOP] list=%d entity=%p prev=%p next=%p kind=%u id=%u action=%u type=%u type2=%u\n",
-                        listIdx, (void*)entity, (void*)entity->prev, (void*)entity->next, entity->kind, entity->id,
-                        entity->action, entity->type, entity->type2);
-            }
-#endif
             /* Save current entity in context */
             gUpdateContext.current_entity = entity;
 

--- a/port/port_hdma.c
+++ b/port/port_hdma.c
@@ -1,0 +1,99 @@
+#include "port_hdma.h"
+
+#include <string.h>
+
+#define HDMA_CHANNELS 4
+
+#define DMA_CNT_DEST_FIXED  0x0040
+#define DMA_CNT_DEST_RELOAD 0x0060
+#define DMA_CNT_DEST_MASK   0x0060
+#define DMA_CNT_SRC_FIXED   0x0100
+#define DMA_CNT_32BIT       0x0400
+
+typedef struct {
+    int active;
+    const uint8_t* src_orig;
+    const uint8_t* src;
+    uint8_t* dest_orig;
+    uint8_t* dest;
+    uint16_t count;     // units per HBlank transfer
+    uint8_t  unit;      // 2 or 4 bytes
+    uint8_t  src_fixed;
+    uint8_t  dest_reload; // 0 = increment, 1 = reset to dest_orig after each HBlank
+} HdmaChannel;
+
+static HdmaChannel s_channels[HDMA_CHANNELS];
+
+void port_hdma_register(int channel, const void* src, void* dest,
+                        uint16_t cnt_h, uint16_t count)
+{
+    HdmaChannel* c;
+    uint16_t dm;
+
+    if (channel < 0 || channel >= HDMA_CHANNELS) {
+        return;
+    }
+    c = &s_channels[channel];
+    c->active = 1;
+    c->src_orig = c->src = (const uint8_t*)src;
+    c->dest_orig = c->dest = (uint8_t*)dest;
+    c->count = count ? count : 1;
+    c->unit = (cnt_h & DMA_CNT_32BIT) ? 4 : 2;
+    c->src_fixed = (cnt_h & DMA_CNT_SRC_FIXED) ? 1 : 0;
+    dm = cnt_h & DMA_CNT_DEST_MASK;
+    c->dest_reload = (dm == DMA_CNT_DEST_FIXED || dm == DMA_CNT_DEST_RELOAD) ? 1 : 0;
+}
+
+void port_hdma_unregister(int channel)
+{
+    if (channel < 0 || channel >= HDMA_CHANNELS) {
+        return;
+    }
+    s_channels[channel].active = 0;
+}
+
+void port_hdma_step_line(int line)
+{
+    int ch;
+
+    (void)line;
+    for (ch = 0; ch < HDMA_CHANNELS; ++ch) {
+        HdmaChannel* c = &s_channels[ch];
+        uint8_t* d;
+        uint16_t i;
+
+        if (!c->active) {
+            continue;
+        }
+        d = c->dest;
+        for (i = 0; i < c->count; ++i) {
+            memcpy(d, c->src, c->unit);
+            if (!c->src_fixed) {
+                c->src += c->unit;
+            }
+            if (!c->dest_reload) {
+                d += c->unit;
+            }
+        }
+        c->dest = c->dest_reload ? c->dest_orig : d;
+    }
+}
+
+void port_hdma_vblank_reset(void)
+{
+    int ch;
+
+    /*
+     * TMC re-arms its HBlank DMA via SetVBlankDMA each frame, so registers
+     * are typically refreshed during VBlank. If a channel happens to outlive
+     * the frame, rewind src/dest so the same per-scanline table replays.
+     */
+    for (ch = 0; ch < HDMA_CHANNELS; ++ch) {
+        HdmaChannel* c = &s_channels[ch];
+        if (!c->active) {
+            continue;
+        }
+        c->src = c->src_orig;
+        c->dest = c->dest_orig;
+    }
+}

--- a/port/port_hdma.h
+++ b/port/port_hdma.h
@@ -1,0 +1,31 @@
+#ifndef PORT_HDMA_H
+#define PORT_HDMA_H
+
+/*
+ * Software simulation of GBA HBlank-triggered DMA channels.
+ *
+ * On hardware, a DMA configured with DMA_START_HBLANK | DMA_REPEAT transfers
+ * `count` units from src to dest at every HBlank. TMC uses this for the iris
+ * circle / window effects (per-scanline WIN0H).
+ *
+ * The host PPU renders frames as a single batch, so we drive HDMA from the
+ * VirtuaPPU mode-1 pre-line callback: one transfer per scanline.
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void port_hdma_register(int channel, const void* src, void* dest,
+                        uint16_t cnt_h, uint16_t count);
+void port_hdma_unregister(int channel);
+void port_hdma_step_line(int line);
+void port_hdma_vblank_reset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/port/port_m4a_backend.cpp
+++ b/port/port_m4a_backend.cpp
@@ -142,6 +142,7 @@ static std::string LoadSoundsJson(void) {
         }
     }
 
+    std::fprintf(stderr, "[AUDIO] sounds.json not found — songs will be silent\n");
     return {};
 }
 

--- a/port/port_main.c
+++ b/port/port_main.c
@@ -194,7 +194,8 @@ int main(int argc, char* argv[]) {
 
     Port_Config_OpenGamepads();
 
-    SDL_Window* window = SDL_CreateWindow("The Minish Cap", 240 * window_scale, 160 * window_scale, 0);
+    SDL_Window* window = SDL_CreateWindow(
+        "The Minish Cap", 240 * window_scale, 160 * window_scale, SDL_WINDOW_RESIZABLE);
     if (window == NULL) {
         fprintf(stderr, "SDL_CreateWindow Error: %s\n", SDL_GetError());
         SDL_Quit();

--- a/port/port_main.c
+++ b/port/port_main.c
@@ -78,16 +78,16 @@ static bool Port_InitVideo(void) {
         SDL_Quit();
     }
 
-    if (display && display[0] != '\0') {
-        if (Port_TryInitVideo("x11", NULL, false)) {
+    if (waylandDisplay && waylandDisplay[0] != '\0') {
+        if (Port_TryInitVideo("wayland", NULL, false)) {
             return true;
         }
         err = SDL_GetError();
         SDL_Quit();
     }
 
-    if (waylandDisplay && waylandDisplay[0] != '\0') {
-        if (Port_TryInitVideo("wayland", NULL, false)) {
+    if (display && display[0] != '\0') {
+        if (Port_TryInitVideo("x11", NULL, false)) {
             return true;
         }
         err = SDL_GetError();

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -170,9 +170,10 @@ extern "C" void Port_PPU_PresentFrame(void) {
 
     switch (gbaMode) {
         case 0:
+        case 1:
             virtuappu_registers.mode = 1;
             break;
-        case 1:
+        
         case 2:
             virtuappu_registers.mode = 2;
             break;

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -1,11 +1,14 @@
 #include "port_ppu.h"
 #include "port_gba_mem.h"
+#include "port_hdma.h"
+#include "port_upscale.h"
 
 #include <cpu/mode1.h>
 #include <virtuappu.h>
 
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 
 enum class RenderBackend {
     None,
@@ -13,19 +16,59 @@ enum class RenderBackend {
     Surface,
 };
 
+/* User-cycled presentation modes. F12 advances through these. */
+enum class PresentMode {
+    NearestRaw = 0,   /* upload 240x160 directly, nearest-neighbor stretch  */
+    XbrzLinear,       /* xBRZ 4x → 960x640, linear stretch (smooth, default) */
+    XbrzNearest,      /* xBRZ 4x → 960x640, nearest stretch (sharp)          */
+    LinearRaw,        /* upload 240x160 directly, linear stretch (blurry)    */
+    Count
+};
+
+static const int kHiResW = 960;
+static const int kHiResH = 640;
+
 static RenderBackend sBackend = RenderBackend::None;
 static SDL_Renderer* sRenderer = nullptr;
-static SDL_Texture* sTexture = nullptr;
+static SDL_Texture* sLowResTexture = nullptr;   /* 240x160 raw upload */
+static SDL_Texture* sHiResTexture = nullptr;    /* 960x640 upscaled  */
 static SDL_Window* sWindow = nullptr;
 static SDL_Surface* sFrameSurface = nullptr;
+static PresentMode sPresentMode = PresentMode::XbrzLinear;
+static uint32_t* sUpscale2xBuf = nullptr;       /* 480x320 intermediate */
+static uint32_t* sUpscale4xBuf = nullptr;       /* 960x640 final        */
+
+// Largest 240:160 (3:2) rect fitting inside (w, h), centered.
+static void Port_PPU_ComputeFitRect(int w, int h, int* outX, int* outY, int* outW, int* outH) {
+    int rw;
+    int rh;
+    if (w * 160 >= h * 240) {
+        rh = h;
+        rw = (h * 240) / 160;
+    } else {
+        rw = w;
+        rh = (w * 160) / 240;
+    }
+    *outX = (w - rw) / 2;
+    *outY = (h - rh) / 2;
+    *outW = rw;
+    *outH = rh;
+}
 
 static void Port_PPU_PresentSurfaceFrame(void) {
     SDL_Surface* windowSurface = SDL_GetWindowSurface(sWindow);
+    int x;
+    int y;
+    int w;
+    int h;
+    SDL_Rect dstRect;
+
     if (!windowSurface) {
         return;
     }
 
-    SDL_Rect dstRect = {0, 0, windowSurface->w, windowSurface->h};
+    Port_PPU_ComputeFitRect(windowSurface->w, windowSurface->h, &x, &y, &w, &h);
+    dstRect = {x, y, w, h};
     SDL_FillSurfaceRect(windowSurface, nullptr, 0);
     SDL_BlitSurfaceScaled(sFrameSurface, nullptr, windowSurface, &dstRect, SDL_SCALEMODE_NEAREST);
     SDL_UpdateWindowSurface(sWindow);
@@ -38,13 +81,17 @@ extern "C" void Port_PPU_Init(SDL_Window* window) {
     if (!sRenderer) {
         printf("Port_PPU_Init: SDL_CreateRenderer failed: %s\n", SDL_GetError());
     } else {
-        sTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STREAMING, 240, 160);
-        if (!sTexture) {
+        sLowResTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ABGR8888,
+                                           SDL_TEXTUREACCESS_STREAMING, 240, 160);
+        sHiResTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ABGR8888,
+                                          SDL_TEXTUREACCESS_STREAMING, kHiResW, kHiResH);
+        if (!sLowResTexture || !sHiResTexture) {
             printf("Port_PPU_Init: SDL_CreateTexture failed: %s\n", SDL_GetError());
             SDL_DestroyRenderer(sRenderer);
             sRenderer = nullptr;
         } else {
-            SDL_SetTextureScaleMode(sTexture, SDL_SCALEMODE_NEAREST);
+            sUpscale2xBuf = (uint32_t*)std::malloc((size_t)480 * 320 * sizeof(uint32_t));
+            sUpscale4xBuf = (uint32_t*)std::malloc((size_t)kHiResW * kHiResH * sizeof(uint32_t));
             sBackend = RenderBackend::Renderer;
         }
     }
@@ -59,6 +106,9 @@ extern "C" void Port_PPU_Init(SDL_Window* window) {
         };
         virtuappu_mode1_bind_gba_memory(&memory);
     }
+
+    /* HBlank-DMA simulation: VirtuaPPU calls this before each scanline. */
+    virtuappu_mode1_pre_line_callback = port_hdma_step_line;
 
     virtuappu_registers.frame_width = 240;
     virtuappu_registers.mode = 1;
@@ -103,21 +153,61 @@ extern "C" void Port_PPU_PresentFrame(void) {
 
     switch (gbaMode) {
         case 0:
+        case 1:
             virtuappu_registers.mode = 1;
             break;
-        case 1:
+        case 2:
             virtuappu_registers.mode = 2;
             break;
         default:
+            virtuappu_registers.mode = 1;
             break;
     }
 
     virtuappu_render_frame();
 
     if (sBackend == RenderBackend::Renderer) {
-        SDL_UpdateTexture(sTexture, nullptr, virtuappu_frame_buffer, 240 * sizeof(uint32_t));
+        int outW = 0;
+        int outH = 0;
+        SDL_GetCurrentRenderOutputSize(sRenderer, &outW, &outH);
+        int x;
+        int y;
+        int w;
+        int h;
+        Port_PPU_ComputeFitRect(outW, outH, &x, &y, &w, &h);
+        SDL_FRect dst = { (float)x, (float)y, (float)w, (float)h };
+
+        SDL_Texture* tex;
+        SDL_ScaleMode scale;
+        switch (sPresentMode) {
+            case PresentMode::XbrzLinear:
+            case PresentMode::XbrzNearest:
+                Port_Upscale_xBRZ_4x(virtuappu_frame_buffer, 240, 160,
+                                     sUpscale2xBuf, sUpscale4xBuf);
+                SDL_UpdateTexture(sHiResTexture, nullptr, sUpscale4xBuf,
+                                  kHiResW * (int)sizeof(uint32_t));
+                tex = sHiResTexture;
+                scale = (sPresentMode == PresentMode::XbrzLinear)
+                            ? SDL_SCALEMODE_LINEAR : SDL_SCALEMODE_NEAREST;
+                break;
+            case PresentMode::LinearRaw:
+                SDL_UpdateTexture(sLowResTexture, nullptr, virtuappu_frame_buffer,
+                                  240 * (int)sizeof(uint32_t));
+                tex = sLowResTexture;
+                scale = SDL_SCALEMODE_LINEAR;
+                break;
+            case PresentMode::NearestRaw:
+            default:
+                SDL_UpdateTexture(sLowResTexture, nullptr, virtuappu_frame_buffer,
+                                  240 * (int)sizeof(uint32_t));
+                tex = sLowResTexture;
+                scale = SDL_SCALEMODE_NEAREST;
+                break;
+        }
+        SDL_SetTextureScaleMode(tex, scale);
+        SDL_SetRenderDrawColor(sRenderer, 0, 0, 0, 255);
         SDL_RenderClear(sRenderer);
-        SDL_RenderTexture(sRenderer, sTexture, nullptr, nullptr);
+        SDL_RenderTexture(sRenderer, tex, nullptr, &dst);
         SDL_RenderPresent(sRenderer);
         return;
     }
@@ -132,6 +222,28 @@ extern "C" void Port_PPU_SetWindowTitle(const char* title) {
     SDL_SetWindowTitle(sWindow, title);
 }
 
+extern "C" void Port_PPU_ToggleFullscreen(void) {
+    if (!sWindow) {
+        return;
+    }
+    SDL_WindowFlags flags = SDL_GetWindowFlags(sWindow);
+    bool wantFullscreen = (flags & SDL_WINDOW_FULLSCREEN) == 0;
+    SDL_SetWindowFullscreen(sWindow, wantFullscreen);
+    SDL_SyncWindow(sWindow);
+}
+
+extern "C" void Port_PPU_ToggleSmoothing(void) {
+    static const char* const kNames[] = {
+        "nearest (sharp pixels)",
+        "xBRZ 4x + linear (smooth, default)",
+        "xBRZ 4x + nearest (crisp upscale)",
+        "linear (blurry stretch)",
+    };
+    int next = ((int)sPresentMode + 1) % (int)PresentMode::Count;
+    sPresentMode = (PresentMode)next;
+    fprintf(stderr, "PPU upscale: %s\n", kNames[next]);
+}
+
 extern "C" void Port_PPU_Shutdown(void) {
     if (sWindow && sBackend == RenderBackend::Surface) {
         SDL_DestroyWindowSurface(sWindow);
@@ -140,9 +252,21 @@ extern "C" void Port_PPU_Shutdown(void) {
         SDL_DestroySurface(sFrameSurface);
         sFrameSurface = nullptr;
     }
-    if (sTexture) {
-        SDL_DestroyTexture(sTexture);
-        sTexture = nullptr;
+    if (sLowResTexture) {
+        SDL_DestroyTexture(sLowResTexture);
+        sLowResTexture = nullptr;
+    }
+    if (sHiResTexture) {
+        SDL_DestroyTexture(sHiResTexture);
+        sHiResTexture = nullptr;
+    }
+    if (sUpscale2xBuf) {
+        std::free(sUpscale2xBuf);
+        sUpscale2xBuf = nullptr;
+    }
+    if (sUpscale4xBuf) {
+        std::free(sUpscale4xBuf);
+        sUpscale4xBuf = nullptr;
     }
     if (sRenderer) {
         SDL_DestroyRenderer(sRenderer);

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -2,6 +2,8 @@
 #include "port_gba_mem.h"
 #include "port_hdma.h"
 #include "port_upscale.h"
+#include "port_runtime_config.h"
+
 
 #include <cpu/mode1.h>
 #include <virtuappu.h>
@@ -9,6 +11,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 
 enum class RenderBackend {
     None,
@@ -37,6 +40,19 @@ static SDL_Surface* sFrameSurface = nullptr;
 static PresentMode sPresentMode = PresentMode::XbrzLinear;
 static uint32_t* sUpscale2xBuf = nullptr;       /* 480x320 intermediate */
 static uint32_t* sUpscale4xBuf = nullptr;       /* 960x640 final        */
+
+static void Port_PPU_LoadConfig(void) {
+    const char* method = Port_Config_UpscaleMethod();
+    if (std::strcmp(method, "nearest") == 0) {
+        sPresentMode = PresentMode::NearestRaw;
+    } else if (std::strcmp(method, "linear") == 0) {
+        sPresentMode = PresentMode::LinearRaw;
+    } else if (std::strcmp(method, "xbrz_nearest") == 0) {
+        sPresentMode = PresentMode::XbrzNearest;
+    } else {
+        sPresentMode = PresentMode::XbrzLinear;
+    }
+}
 
 // Largest 240:160 (3:2) rect fitting inside (w, h), centered.
 static void Port_PPU_ComputeFitRect(int w, int h, int* outX, int* outY, int* outW, int* outH) {
@@ -76,6 +92,7 @@ static void Port_PPU_PresentSurfaceFrame(void) {
 
 extern "C" void Port_PPU_Init(SDL_Window* window) {
     sWindow = window;
+    Port_PPU_LoadConfig();
 
     sRenderer = SDL_CreateRenderer(window, nullptr);
     if (!sRenderer) {

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -170,10 +170,9 @@ extern "C" void Port_PPU_PresentFrame(void) {
 
     switch (gbaMode) {
         case 0:
-        case 1:
             virtuappu_registers.mode = 1;
             break;
-        
+        case 1:
         case 2:
             virtuappu_registers.mode = 2;
             break;

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -37,7 +37,7 @@ static SDL_Texture* sLowResTexture = nullptr;   /* 240x160 raw upload */
 static SDL_Texture* sHiResTexture = nullptr;    /* 960x640 upscaled  */
 static SDL_Window* sWindow = nullptr;
 static SDL_Surface* sFrameSurface = nullptr;
-static PresentMode sPresentMode = PresentMode::XbrzLinear;
+static PresentMode sPresentMode = PresentMode::NearestRaw;
 static uint32_t* sUpscale2xBuf = nullptr;       /* 480x320 intermediate */
 static uint32_t* sUpscale4xBuf = nullptr;       /* 960x640 final        */
 

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -153,9 +153,9 @@ extern "C" void Port_PPU_PresentFrame(void) {
 
     switch (gbaMode) {
         case 0:
-        case 1:
             virtuappu_registers.mode = 1;
             break;
+        case 1:
         case 2:
             virtuappu_registers.mode = 2;
             break;

--- a/port/port_ppu.cpp
+++ b/port/port_ppu.cpp
@@ -98,6 +98,9 @@ extern "C" void Port_PPU_Init(SDL_Window* window) {
     if (!sRenderer) {
         printf("Port_PPU_Init: SDL_CreateRenderer failed: %s\n", SDL_GetError());
     } else {
+        if (!SDL_SetRenderVSync(sRenderer, 1)) {
+            printf("Port_PPU_Init: SDL_SetRenderVSync failed: %s\n", SDL_GetError());
+        }
         sLowResTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ABGR8888,
                                            SDL_TEXTUREACCESS_STREAMING, 240, 160);
         sHiResTexture = SDL_CreateTexture(sRenderer, SDL_PIXELFORMAT_ABGR8888,
@@ -170,9 +173,9 @@ extern "C" void Port_PPU_PresentFrame(void) {
 
     switch (gbaMode) {
         case 0:
+        case 1:
             virtuappu_registers.mode = 1;
             break;
-        case 1:
         case 2:
             virtuappu_registers.mode = 2;
             break;

--- a/port/port_ppu.h
+++ b/port/port_ppu.h
@@ -17,6 +17,12 @@ void Port_PPU_PresentFrame(void);
 // Update the SDL window title used by the port.
 void Port_PPU_SetWindowTitle(const char* title);
 
+// Toggle borderless desktop fullscreen on the SDL window.
+void Port_PPU_ToggleFullscreen(void);
+
+// Toggle nearest-neighbor (sharp pixels) ↔ linear (smooth) upscale filter.
+void Port_PPU_ToggleSmoothing(void);
+
 // Cleanup
 void Port_PPU_Shutdown(void);
 

--- a/port/port_runtime_config.cpp
+++ b/port/port_runtime_config.cpp
@@ -37,11 +37,12 @@ const std::array<Def, PORT_INPUT_COUNT> kDefaults = {{
 
 u8 sScale = 3;
 std::string sUpscaleMethod = "nearest";
+u64 sFrameTimeNs = 16666667;
 std::array<std::vector<Bind>, PORT_INPUT_COUNT> sBinds;
 std::vector<SDL_Gamepad*> sPads;
 
 nlohmann::json DefaultsJson(void) {
-    nlohmann::json j = { { "window_scale", 3 }, { "upscale_method", "nearest" }, { "bindings", nlohmann::json::object() } };
+    nlohmann::json j = { { "window_scale", 3 }, { "upscale_method", "nearest" }, { "frame_time_ns", 16666667 }, { "bindings", nlohmann::json::object() } };
     for (const auto& d : kDefaults) {
         j["bindings"][d.name] = nlohmann::json::array();
         for (const char* bind : d.binds) {
@@ -121,7 +122,11 @@ extern "C" void Port_Config_Load(const char* path) {
 
     int scale = j.value("window_scale", 3);
     sScale = scale >= 1 && scale <= 10 ? (u8)scale : 3;
-    sUpscaleMethod = j.value("upscale_method", "xbrz_linear");
+    sUpscaleMethod = j.value("upscale_method", "nearest");
+    sFrameTimeNs = j.value("frame_time_ns", 16666667ULL);
+    if (sFrameTimeNs < 1000000) {
+        sFrameTimeNs = 1000000;
+    }
 
     for (auto& v : sBinds) {
         v.clear();
@@ -139,6 +144,10 @@ extern "C" u8 Port_Config_WindowScale(void) {
 
 extern "C" const char* Port_Config_UpscaleMethod(void) {
     return sUpscaleMethod.c_str();
+}
+
+extern "C" u64 Port_Config_FrameTimeNs(void) {
+    return sFrameTimeNs;
 }
 
 extern "C" void Port_Config_OpenGamepads(void) {

--- a/port/port_runtime_config.cpp
+++ b/port/port_runtime_config.cpp
@@ -36,11 +36,12 @@ const std::array<Def, PORT_INPUT_COUNT> kDefaults = {{
 }};
 
 u8 sScale = 3;
+std::string sUpscaleMethod = "nearest";
 std::array<std::vector<Bind>, PORT_INPUT_COUNT> sBinds;
 std::vector<SDL_Gamepad*> sPads;
 
 nlohmann::json DefaultsJson(void) {
-    nlohmann::json j = { { "window_scale", 3 }, { "bindings", nlohmann::json::object() } };
+    nlohmann::json j = { { "window_scale", 3 }, { "upscale_method", "nearest" }, { "bindings", nlohmann::json::object() } };
     for (const auto& d : kDefaults) {
         j["bindings"][d.name] = nlohmann::json::array();
         for (const char* bind : d.binds) {
@@ -120,6 +121,7 @@ extern "C" void Port_Config_Load(const char* path) {
 
     int scale = j.value("window_scale", 3);
     sScale = scale >= 1 && scale <= 10 ? (u8)scale : 3;
+    sUpscaleMethod = j.value("upscale_method", "xbrz_linear");
 
     for (auto& v : sBinds) {
         v.clear();
@@ -133,6 +135,10 @@ extern "C" void Port_Config_Load(const char* path) {
 
 extern "C" u8 Port_Config_WindowScale(void) {
     return sScale;
+}
+
+extern "C" const char* Port_Config_UpscaleMethod(void) {
+    return sUpscaleMethod.c_str();
 }
 
 extern "C" void Port_Config_OpenGamepads(void) {

--- a/port/port_runtime_config.h
+++ b/port/port_runtime_config.h
@@ -25,6 +25,7 @@ typedef enum {
 void Port_Config_Load(const char* path);
 u8 Port_Config_WindowScale(void);
 const char* Port_Config_UpscaleMethod(void);
+u64 Port_Config_FrameTimeNs(void);
 void Port_Config_OpenGamepads(void);
 void Port_Config_HandleEvent(const SDL_Event* e);
 bool Port_Config_InputPressed(PortInput input);

--- a/port/port_runtime_config.h
+++ b/port/port_runtime_config.h
@@ -24,6 +24,7 @@ typedef enum {
 
 void Port_Config_Load(const char* path);
 u8 Port_Config_WindowScale(void);
+const char* Port_Config_UpscaleMethod(void);
 void Port_Config_OpenGamepads(void);
 void Port_Config_HandleEvent(const SDL_Event* e);
 bool Port_Config_InputPressed(PortInput input);

--- a/port/port_upscale.c
+++ b/port/port_upscale.c
@@ -1,0 +1,140 @@
+#include "port_upscale.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/*
+ * xBRZ-inspired pixel-art upscaler (clean-room).
+ *
+ * Compared to plain nearest-neighbor stretch, this:
+ *   - Detects diagonal edges using YCbCr color distance (not strict equality),
+ *     so JPEG-ish dithered pixel art still gets smoothed.
+ *   - Blends two colors at detected diagonal cuts (50/50 mix), producing
+ *     anti-aliased diagonals instead of the staircase you get with Scale2x.
+ *   - Avoids smoothing near isolated pixels (no "bleed" inside texture
+ *     details) by requiring edge symmetry.
+ *
+ * The 5x5 neighborhood:
+ *
+ *      .  .  .  .  .
+ *      .  A  .  .  .
+ *      .  Bl M  Br .
+ *      .  .  D  .  .
+ *      .  .  .  .  .
+ *
+ * For each output 2x2 sub-block, we examine the four diagonal "corner"
+ * directions (NW, NE, SW, SE) and replace the corresponding sub-pixel with
+ * a blend of the two cardinal neighbors that bracket the diagonal — but
+ * only when:
+ *   1. the two cardinal neighbors are similar to each other,
+ *   2. they differ from the center M, and
+ *   3. they don't form a stronger pattern with the opposite cardinal
+ *      (which would mean we're inside a texture, not on an edge).
+ */
+
+/* Squared YCbCr distance threshold. Tune to taste:
+ *   smaller → fewer pixels marked similar → less blending, sharper output.
+ *   larger  → more aggressive blending, can blur pixel art.
+ * 36^2 = 1296 picks up gentle dithering without smearing distinct colors. */
+#define COLOR_THRESHOLD_SQ (36 * 36)
+
+static inline int color_dist_sq(uint32_t a, uint32_t b) {
+    int ar, ag, ab;
+    int br, bg, bb;
+    int dr, dg, db;
+    int dy, dcb, dcr;
+
+    if (a == b) {
+        return 0;
+    }
+    /* SDL_PIXELFORMAT_ABGR8888: byte 0=R, 1=G, 2=B, 3=A. */
+    ar = (int)(a & 0xFF);
+    ag = (int)((a >> 8) & 0xFF);
+    ab = (int)((a >> 16) & 0xFF);
+    br = (int)(b & 0xFF);
+    bg = (int)((b >> 8) & 0xFF);
+    bb = (int)((b >> 16) & 0xFF);
+    dr = ar - br;
+    dg = ag - bg;
+    db = ab - bb;
+    /* Approximate BT.601 in fixed-point (×1000). */
+    dy = (299 * dr + 587 * dg + 114 * db) / 1000;
+    dcb = (-169 * dr - 331 * dg + 500 * db) / 1000;
+    dcr = (500 * dr - 418 * dg - 81 * db) / 1000;
+    /* Weight luma higher than chroma — humans notice luminance edges more. */
+    return dy * dy * 4 + dcb * dcb + dcr * dcr;
+}
+
+static inline int sim(uint32_t a, uint32_t b) {
+    return color_dist_sq(a, b) < COLOR_THRESHOLD_SQ;
+}
+
+/* 50/50 alpha blend of two ABGR8888 pixels. */
+static inline uint32_t blend2(uint32_t a, uint32_t b) {
+    return ((a >> 1) & 0x7F7F7F7Fu) + ((b >> 1) & 0x7F7F7F7Fu);
+}
+
+/* 75/25 blend (3*a + b) / 4. Used for corner anti-aliasing. */
+static inline uint32_t blend3(uint32_t a, uint32_t b) {
+    uint32_t lo = (a & 0xFEFEFEFEu) >> 1;
+    uint32_t mid = lo + ((b & 0xFEFEFEFEu) >> 1);
+    return ((a & 0xFEFEFEFEu) >> 1) + ((mid & 0xFEFEFEFEu) >> 1);
+}
+
+void Port_Upscale_xBRZ_2x(const uint32_t* src, int srcW, int srcH, uint32_t* dst) {
+    int x;
+    int y;
+    int dstW = srcW * 2;
+
+    for (y = 0; y < srcH; y++) {
+        for (x = 0; x < srcW; x++) {
+            uint32_t M;     /* center */
+            uint32_t Lt;    /* left  */
+            uint32_t R;     /* right */
+            uint32_t U;     /* up    */
+            uint32_t Dn;    /* down  */
+            uint32_t TL;    /* output 2x2 sub-pixels */
+            uint32_t TR;
+            uint32_t BL;
+            uint32_t BR;
+
+            M  = src[y * srcW + x];
+            Lt = (x > 0)        ? src[y * srcW + (x - 1)]   : M;
+            R  = (x < srcW - 1) ? src[y * srcW + (x + 1)]   : M;
+            U  = (y > 0)        ? src[(y - 1) * srcW + x]   : M;
+            Dn = (y < srcH - 1) ? src[(y + 1) * srcW + x]   : M;
+
+            TL = TR = BL = BR = M;
+
+            /* For each diagonal corner, blend two cardinal neighbors when:
+             *   - they are similar to each other (forming a continuous edge),
+             *   - they differ from the center (we are on an edge, not inside),
+             *   - the orthogonal pair (in the same corner) does NOT form an
+             *     equally strong edge (otherwise we're at an X-junction; both
+             *     diagonals would compete and we'd over-smooth). */
+            if (sim(U, Lt) && !sim(U, M) && !sim(Lt, R) && !sim(U, Dn)) {
+                TL = blend2(U, Lt);
+            }
+            if (sim(U, R)  && !sim(U, M) && !sim(R, Lt) && !sim(U, Dn)) {
+                TR = blend2(U, R);
+            }
+            if (sim(Dn, Lt) && !sim(Dn, M) && !sim(Lt, R) && !sim(Dn, U)) {
+                BL = blend2(Dn, Lt);
+            }
+            if (sim(Dn, R)  && !sim(Dn, M) && !sim(R, Lt) && !sim(Dn, U)) {
+                BR = blend2(Dn, R);
+            }
+
+            dst[(2 * y)     * dstW + (2 * x)]     = TL;
+            dst[(2 * y)     * dstW + (2 * x + 1)] = TR;
+            dst[(2 * y + 1) * dstW + (2 * x)]     = BL;
+            dst[(2 * y + 1) * dstW + (2 * x + 1)] = BR;
+        }
+    }
+}
+
+void Port_Upscale_xBRZ_4x(const uint32_t* src, int srcW, int srcH,
+                          uint32_t* scratch2x, uint32_t* dst) {
+    Port_Upscale_xBRZ_2x(src, srcW, srcH, scratch2x);
+    Port_Upscale_xBRZ_2x(scratch2x, srcW * 2, srcH * 2, dst);
+}

--- a/port/port_upscale.h
+++ b/port/port_upscale.h
@@ -1,0 +1,27 @@
+#ifndef PORT_UPSCALE_H
+#define PORT_UPSCALE_H
+
+/*
+ * Pixel-art-aware software upscaler. xBRZ-inspired clean-room implementation:
+ * detects edges via YCbCr color distance, blends two colors at diagonal cuts.
+ * Operates on 32-bit ABGR pixels (matches virtuappu_frame_buffer layout).
+ *
+ * dst must point to a buffer of (srcW * 2) * (srcH * 2) uint32_t for 2x,
+ * (srcW * 4) * (srcH * 4) for 4x.
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void Port_Upscale_xBRZ_2x(const uint32_t* src, int srcW, int srcH, uint32_t* dst);
+void Port_Upscale_xBRZ_4x(const uint32_t* src, int srcW, int srcH,
+                          uint32_t* scratch2x, uint32_t* dst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/port/stubs_autogen.c
+++ b/port/stubs_autogen.c
@@ -678,7 +678,7 @@ u8 gUnk_03003DE4[0xC];
 /* m4aSoundVSyncOff -- implemented in port_m4a_stubs.c */
 /* m4aSoundVSyncOn -- implemented in port_m4a_stubs.c */
 /* ram_ClearAndUpdateEntities -- defined in port_draw.c */
-u32 ram_CollideAll(...) {
+u32 ram_CollideAll(void) {
     s32 i;
     s32 j;
 
@@ -791,7 +791,7 @@ u32 ram_CollideAll(...) {
 }
 /* ram_DrawDirect -- defined in port_draw.c */
 /* ram_DrawEntities -- defined in port_draw.c */
-u32 ram_IntrMain(...) {
+u32 ram_IntrMain(void) {
     return 0;
 }
 /* ram_MakeFadeBuff256 -- defined in port_linked_stubs.c */

--- a/src/game.c
+++ b/src/game.c
@@ -245,10 +245,6 @@ static void GameMain_ChangeRoom(void) {
 }
 
 static void GameMain_Update(void) {
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] GameMain_Update begin area=%u room=%u substate=%u msg=0x%X\n", gRoomControls.area,
-            gRoomControls.room, gMain.substate, gMessage.state);
-#endif
     if (CheckInitPauseMenu() || CheckInitPortal()) {
         return;
     }
@@ -262,34 +258,16 @@ static void GameMain_Update(void) {
     if ((gMessage.state & MESSAGE_ACTIVE) || gPriorityHandler.priority_timer != 0)
         PausePlayer();
 
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] UpdateEntities\n");
-#endif
     FlushSprites();
     UpdateEntities();
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] UpdateDoorTransition\n");
-#endif
     UpdateDoorTransition();
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] CollisionMain\n");
-#endif
     CollisionMain();
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] UpdateScroll\n");
-#endif
     UpdateScroll();
     UpdateBgAnimations();
     UpdateScrollVram();
     DecreasePortalTimer();
     DrawUI();
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] UpdateManagers\n");
-#endif
     UpdateManagers();
-#ifdef PC_PORT
-    fprintf(stderr, "[FRAME] DrawUIElements\n");
-#endif
     DrawUIElements();
     UpdateCarriedObject();
     DrawEntities();

--- a/src/manager/lightRayManager.c
+++ b/src/manager/lightRayManager.c
@@ -116,10 +116,6 @@ void LightRayManager_Action1(LightRayManager* this) {
     s32 y;
 
     if (prop == NULL) {
-#ifdef PC_PORT
-        fprintf(stderr, "[LIGHT] missing property list type=%u area=%u room=%u\n", super->type, gRoomControls.area,
-                gRoomControls.room);
-#endif
         return;
     }
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -352,6 +352,8 @@ target("tmc_pc")
     add_files("port/port_linked_stubs.c")
     add_files("port/port_draw.c")
     add_files("port/port_gba_mem.c")
+    add_files("port/port_hdma.c")    -- HBlank-DMA simulation (iris/circle WIN0H)
+    add_files("port/port_upscale.c") -- xBRZ-style pixel-art upscaler
     add_files("port/port_save.c")        -- EEPROM save emulation
     add_files("port/port_animation.c")   -- Animation system (ported from ASM)
     add_files("port/port_math.c")        -- Math functions (CalcDistance, direction, Sqrt, Div)

--- a/xmake.lua
+++ b/xmake.lua
@@ -311,7 +311,27 @@ target("tmc_pc")
     set_kind("binary")
     set_languages("c11", "cxx20")
     set_targetdir("build/pc")
-    
+
+    -- Apply the ViruaPPU HBlank-DMA callback patch before compilation.
+    -- The submodule is intentionally pinned at upstream; this patch adds
+    -- the virtuappu_mode1_pre_line_callback hook that port_hdma needs.
+    -- Idempotent: skipped if the marker symbol is already in mode1.h.
+    before_build(function (target)
+        local sub = path.join(os.projectdir(), "libs", "ViruaPPU")
+        local marker_file = path.join(sub, "include", "cpu", "mode1.h")
+        local patch_file = path.join(os.projectdir(), "port", "patches",
+                                     "viruappu-hdma-hook.patch")
+        if not os.isfile(marker_file) or not os.isfile(patch_file) then
+            return
+        end
+        local content = io.readfile(marker_file)
+        if content and content:find("virtuappu_mode1_pre_line_callback", 1, true) then
+            return
+        end
+        print("[viruappu] applying %s", path.relative(patch_file, os.projectdir()))
+        os.execv("git", {"-C", sub, "apply", patch_file})
+    end)
+
     -- PC port version configurations
     local pc_versions = {
         USA = { region = "USA", language = "ENGLISH" },

--- a/xmake.lua
+++ b/xmake.lua
@@ -312,28 +312,34 @@ target("tmc_pc")
     set_languages("c11", "cxx20")
     set_targetdir("build/pc")
 
-    -- Apply the ViruaPPU HBlank-DMA callback patch before compilation.
-    -- The submodule is intentionally pinned at upstream; this patch adds
-    -- the virtuappu_mode1_pre_line_callback hook that port_hdma needs to
-    -- both mode1.c and mode2.c render loops.
-    -- Idempotent: skipped if the mode2.c hook is already present. If the
-    -- patch was applied with an older revision (mode1 only), reset the
-    -- submodule (`git -C libs/ViruaPPU checkout -- .`) so the new combined
-    -- patch can apply cleanly.
+    -- Apply the ViruaPPU patches before compilation. The submodule is
+    -- intentionally pinned at upstream; each patch is idempotent and
+    -- skipped when its marker symbol is already present in the target file.
+    -- If a patch was applied with an older revision, reset the submodule
+    -- (`git -C libs/ViruaPPU checkout -- .`) so the patches reapply cleanly.
     before_build(function (target)
         local sub = path.join(os.projectdir(), "libs", "ViruaPPU")
-        local marker_file = path.join(sub, "src", "mode2.c")
-        local patch_file = path.join(os.projectdir(), "port", "patches",
-                                     "viruappu-hdma-hook.patch")
-        if not os.isfile(marker_file) or not os.isfile(patch_file) then
-            return
+        local patches_dir = path.join(os.projectdir(), "port", "patches")
+        local patches = {
+            -- HDMA per-line callback hook in mode1.c and mode2.c render loops.
+            { patch = "viruappu-hdma-hook.patch",
+              marker_file = path.join(sub, "src", "mode2.c"),
+              marker = "virtuappu_mode1_pre_line_callback" },
+            -- BG mosaic support: BGCNT bit 6 + REG_MOSAIC quantize sample coords.
+            { patch = "viruappu-mosaic.patch",
+              marker_file = path.join(sub, "include", "cpu", "mode1.h"),
+              marker = "MODE1_IO_MOSAIC" },
+        }
+        for _, p in ipairs(patches) do
+            local patch_file = path.join(patches_dir, p.patch)
+            if os.isfile(p.marker_file) and os.isfile(patch_file) then
+                local content = io.readfile(p.marker_file)
+                if not (content and content:find(p.marker, 1, true)) then
+                    print("[viruappu] applying %s", path.relative(patch_file, os.projectdir()))
+                    os.execv("git", {"-C", sub, "apply", patch_file})
+                end
+            end
         end
-        local content = io.readfile(marker_file)
-        if content and content:find("virtuappu_mode1_pre_line_callback", 1, true) then
-            return
-        end
-        print("[viruappu] applying %s", path.relative(patch_file, os.projectdir()))
-        os.execv("git", {"-C", sub, "apply", patch_file})
     end)
 
     -- PC port version configurations

--- a/xmake.lua
+++ b/xmake.lua
@@ -314,11 +314,15 @@ target("tmc_pc")
 
     -- Apply the ViruaPPU HBlank-DMA callback patch before compilation.
     -- The submodule is intentionally pinned at upstream; this patch adds
-    -- the virtuappu_mode1_pre_line_callback hook that port_hdma needs.
-    -- Idempotent: skipped if the marker symbol is already in mode1.h.
+    -- the virtuappu_mode1_pre_line_callback hook that port_hdma needs to
+    -- both mode1.c and mode2.c render loops.
+    -- Idempotent: skipped if the mode2.c hook is already present. If the
+    -- patch was applied with an older revision (mode1 only), reset the
+    -- submodule (`git -C libs/ViruaPPU checkout -- .`) so the new combined
+    -- patch can apply cleanly.
     before_build(function (target)
         local sub = path.join(os.projectdir(), "libs", "ViruaPPU")
-        local marker_file = path.join(sub, "include", "cpu", "mode1.h")
+        local marker_file = path.join(sub, "src", "mode2.c")
         local patch_file = path.join(os.projectdir(), "port", "patches",
                                      "viruappu-hdma-hook.patch")
         if not os.isfile(marker_file) or not os.isfile(patch_file) then


### PR DESCRIPTION
## Summary

Builds on the original `feat/hdma-xbrz-fullscreen` work (5e219644) and adds the missing pieces needed for it to actually build and run correctly on a clean clone:

- **HDMA scanline simulation** — restores the iris/circle WIN0H effect at door transitions and per-scanline window writes around fades.
- **xBRZ 4× upscaler** with four runtime-cyclable present modes (F12 cycles `NearestRaw → XbrzLinear → XbrzNearest → LinearRaw`).
- **Borderless fullscreen toggle** (Alt+Enter).
- **OBJ-affine BIOS fix** — `ObjAffineSet` now computes the inverse texture-mapping matrix, so affine sprites (lily pads etc.) actually move.

## Fixes added on top of the original branch

- **Title-screen sword regression**: `port_ppu.cpp` was routing GBA mode 1 to VirtuaPPU mode 1, but VirtuaPPU mode 1 renders all four BGs as text BGs — the affine BG2 tilemap (which the title-screen sword lives on) came out as garbage tiles. VirtuaPPU mode 2 already does what GBA mode 1 hardware does (BG0/1 text + BG2 affine + OBJ), so the case statement now routes GBA mode 1 there. GBA mode 0 keeps mode 1; GBA mode 2 keeps mode 2.
- **Cross-compile to Windows with llvm-mingw**: clang rejects unnamed-parameter variadics (`u32 ram_CollideAll(...)`), so two stubs in `port/stubs_autogen.c` now use `(void)`. Both functions take no arguments and all callers in `src/` already declare them as `(void)`. No-op for native gcc on Linux.
- **ViruaPPU patch applied at build time**: the HDMA hook needs a `virtuappu_mode1_pre_line_callback` symbol the upstream submodule doesn't export. Rather than forking ViruaPPU, the patch lives in `port/patches/viruappu-hdma-hook.patch` and is applied by xmake's `before_build` hook (idempotent — checks for the marker symbol and skips if already applied). Submodule pointer stays at upstream `21307036`.

## Test plan

- [x] Linux native build (`xmake f -p linux && xmake build tmc_pc`)
- [x] Windows cross-compile via llvm-mingw (`xmake f -p mingw --mingw=<sdk> && xmake build tmc_pc`)
- [x] Windows binary boots under wine, finds assets, enters AgbMain
- [x] Build hook is idempotent (second build is a no-op)
- [x] Title screen sword renders correctly (affine BG2)
- [x] Title screen background renders correctly (was the original mode-1 fix's reason)
- [x] Door iris/circle transition animates (HDMA scanline hook)
- [x] F12 cycles upscale modes
- [x] Alt+Enter toggles fullscreen

## Notes

After the first build, `libs/ViruaPPU` will show as modified in `git status`. That's expected — the patch was applied to the submodule working tree. `git submodule update` reverts it; the next build re-applies. If we later want a clean submodule status, the next step is to fork ViruaPPU and bump the submodule pointer to the fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)