### PR TITLE
Add roll attack macro (D / R3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Roll attack macro (PC port QoL)
+
+- One-button **start-of-roll attack**: hold a direction and press the bind
+  (default **D** / **R3** right-stick click). Uses your best owned sword
+  without changing A/B equip — same virtual-item pattern as soft slots.
+- Toggle in **F8 → Controls** (`roll_attack_macro` in `config.json`).
+- Rebindable under **F8 → Controls → Roll attack**.
+
 ## v0.7.0 (2026-06-26)
 
 ### Software PPU vendored in-tree (`port/ppu`); ViruaPPU submodule + patch pipeline removed

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ single-target invocation, and other build options.
 | Capture bug report             | F9               | —              |
 | Quicksave                      | F5               | —              |
 | Quickload (also stops speech)  | F6               | —              |
+| Roll attack macro              | D                | R3 (RS click)  |
+
+Hold a direction, then press the roll-attack bind for a start-of-roll sword
+attack (uses your best sword regardless of A/B equip). Toggle in **F8 →
+Controls**. Rebindable there.
 
 The **F8** debug menu also covers warp, items, heal, internal render scale,
 the renderer/shader toggles (see *Renderer & shaders*) and an Accessibility tab

--- a/port/port_bios.c
+++ b/port/port_bios.c
@@ -16,6 +16,7 @@
 #include "port_rom.h"
 #include "port_practice.h"
 #include "port_runtime_config.h"
+#include "port_roll_attack_macro.h"
 #include "port_softslots.h"
 #include "port_touch_controls.h"
 #include "port_tts.h"
@@ -136,7 +137,8 @@ static void Port_UpdateInput(void) {
      * which item to spawn lives in src/playerUtils.c via
      * Port_SoftSlots_GetEffectiveBItem(); the save data is untouched. */
     Port_SoftSlots_Update();
-    if (Port_SoftSlots_IsBHeld()) {
+    Port_RollAttackMacro_Tick(&keyinput);
+    if (Port_SoftSlots_IsBHeld() || Port_RollAttackMacro_IsBHeld()) {
         keyinput &= ~B_BUTTON;
     }
 

--- a/port/port_bios.c
+++ b/port/port_bios.c
@@ -111,6 +111,13 @@ static void Port_UpdateInput(void) {
         Port_ReproRando_Tick(sFrameNum);
     }
 
+    /* Roll-attack macro end-to-end test (TMC_REPRO_ROLL_MACRO=1). Runs BEFORE
+     * Port_RollAttackMacro_Tick() below so its forced UP + ROLL_ATTACK edges
+     * are visible to the macro through the real input path this same frame. */
+    {
+        Port_ReproRollMacro_Tick(sFrameNum);
+    }
+
     {
         /* While either overlay is open, hold all GBA buttons released so
          * the game doesn't observe stray input from key presses we routed

--- a/port/port_imgui_menu.cpp
+++ b/port/port_imgui_menu.cpp
@@ -1100,11 +1100,25 @@ static const char* InputLabel(int input) {
         case PORT_INPUT_SOFT_Y:  return "Soft slot Y";
         case PORT_INPUT_SOFT_L2: return "Soft slot L2";
         case PORT_INPUT_SOFT_R2: return "Soft slot R2";
+        case PORT_INPUT_ROLL_ATTACK: return "Roll attack (D / R3)";
         default:                 return Port_Config_InputName(input);
     }
 }
 
 static void DrawRibbonControlsTab(void) {
+    {
+        bool on = Port_Config_GetRollAttackMacroEnabled();
+        if (ImGui::Checkbox("Roll attack macro", &on)) {
+            Port_Config_SetRollAttackMacroEnabled(on);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "Hold a direction and press the Roll attack bind to perform a "
+                "start-of-roll attack with your best sword, regardless of A/B "
+                "equip.\nDefault: keyboard D, controller R3 (right stick click).");
+        }
+    }
+    ImGui::Separator();
     ImGui::TextWrapped("Click 'Set' to replace an action's binding, or 'Add' to bind an extra "
                        "key/controller button to it, then press the input. Esc cancels. Mappings "
                        "save to config.json automatically. In Console-Parity mode each physical "

--- a/port/port_repro.h
+++ b/port/port_repro.h
@@ -20,6 +20,7 @@ void Port_ReproRando_LateTick(void);
 void Port_ReproPerfcap_Tick(unsigned int frame);
 void Port_ReproA11y_Tick(unsigned int frame);
 void Port_ReproRoomCap_Tick(unsigned int frame);
+void Port_ReproRollMacro_Tick(unsigned int frame);
 
 #ifdef __cplusplus
 }

--- a/port/port_repro_roll_macro.c
+++ b/port/port_repro_roll_macro.c
@@ -1,0 +1,165 @@
+/*
+ * port/port_repro_roll_macro.c — headless end-to-end test for the one-button
+ * roll-attack macro (PR #160, port_roll_attack_macro.c).
+ *
+ * Enable with TMC_REPRO_ROLL_MACRO=1 (headless: TMC_AUTOPLAY=1,
+ * SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy). Optional warp override:
+ *   TMC_REPRO_ROLL_MACRO_WARP="area,room,x,y,layer"  (decimal or 0x-hex)
+ *
+ * Reproduces the macro's documented usage — HOLD a direction (so Link is
+ * walking and R's context-action is roll) then press the bind — entirely
+ * through the real input path: the test-only edge seam
+ * (Port_Config_TestForceEdge) stamps UP + ROLL_ATTACK exactly as an SDL
+ * KEY_DOWN would, and everything downstream is untouched game code
+ * (Port_Config_InputPressed -> Port_RollAttackMacro_Tick state machine ->
+ * roll physics -> PlayerRollUpdate's frame&0x40 window -> UpdateActiveItems
+ * -> the macro's virtual best-sword override).
+ *
+ * Setup that mirrors reality: grant all items (learns SKILL_ROLL_ATTACK +
+ * every sword), clear PL_NO_CAP so the roll uses ANIM_ROLL (the post-Ezlo roll
+ * with the item window; roll attack is always learned long after Ezlo), and
+ * force a NON-sword (Remote Bombs) onto BOTH A and B. A landed roll *attack*
+ * (lastSwordMove == SWORD_MOVE_ROLL) with a non-sword on B can therefore ONLY
+ * come from the macro's Port_RollAttackMacro_GetEffectiveBItem() override.
+ *
+ * Oracle (all four required to PASS): PL_ROLLING seen, the frame&0x40 item
+ * window seen, lastSwordMove == SWORD_MOVE_ROLL, attack_status peaked non-zero,
+ * with B provably non-sword. Exits 0 PASS / 1 FAIL / 3 timeout.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "main.h"
+#include "save.h"
+#include "fileselect.h"
+#include "room.h"
+#include "player.h"
+#include "item_ids.h"
+#include "game.h"
+#include "ui.h"
+#include "port_repro.h"
+#include "port_debug_actions.h"
+#include "port_runtime_config.h"
+
+extern void SetActiveSave(u32 idx);
+
+void Port_ReproRollMacro_Tick(unsigned int frame) {
+    static int active = -1;
+    static int booted = 0, warped = 0, setup = 0;
+    static int walk_from = 0, fired = 0, observe_until = 0;
+    static int saw_rolling = 0, saw_window = 0, saw_roll_move = 0, best_attack = 0;
+    static unsigned int a = 0x03, r = 0x08, x = 0x1d8, y = 0x138, l = 0;
+
+    if (active < 0) {
+        const char* env = getenv("TMC_REPRO_ROLL_MACRO");
+        active = (env && *env && strcmp(env, "0") != 0) ? 1 : 0;
+        if (active) {
+            const char* w = getenv("TMC_REPRO_ROLL_MACRO_WARP");
+            if (w && *w)
+                sscanf(w, "%i,%i,%i,%i,%i", &a, &r, &x, &y, &l);
+            fprintf(stderr, "[roll-macro-test] active warp=0x%02x/0x%02x (%u,%u) layer=%u\n",
+                    a, r, x, y, l);
+        }
+    }
+    if (!active)
+        return;
+
+    if (!booted && gMain.task == TASK_TITLE && frame >= 30 && (frame & 0xF) < 3) {
+        Port_Config_TestForceEdge(PORT_INPUT_START);
+    }
+
+    if (!booted && gMain.task == TASK_FILE_SELECT && frame > 60) {
+        SaveFile* sv = &gMapDataBottomSpecial.saves[0];
+        ResetSaveFile(0);
+        sv->initialized = 1;
+        sv->name[0] = 'A';
+        sv->saved_status.area_next = (u8)a;
+        sv->saved_status.room_next = (u8)r;
+        sv->saved_status.start_pos_x = (s16)x;
+        sv->saved_status.start_pos_y = (s16)y;
+        sv->saved_status.layer = (u8)l;
+        gMapDataBottomSpecial.saveStatus[0] = 1;
+        SetActiveSave(0);
+        SetTask(TASK_GAME);
+        booted = 1;
+        fprintf(stderr, "[roll-macro-test] frame %u: bootstrapped -> TASK_GAME\n", frame);
+    }
+
+    if (booted && !warped && gMain.task == TASK_GAME && frame % 20 == 0) {
+        if (Port_DebugAction_Warp((unsigned char)a, (unsigned char)r,
+                                  (unsigned short)x, (unsigned short)y, (unsigned char)l) == 1) {
+            warped = 1;
+            fprintf(stderr, "[roll-macro-test] frame %u: warped (area=0x%02x room=0x%02x)\n",
+                    frame, (unsigned)gRoomControls.area, (unsigned)gRoomControls.room);
+        }
+    }
+
+    if (warped && !setup && gMain.task == TASK_GAME && frame % 4 == 0 &&
+        gPlayerState.controlMode == CONTROL_ENABLED &&
+        !(gPlayerState.flags & (PL_ROLLING | PL_BUSY | PL_DISABLE_ITEMS))) {
+        Port_DebugAction_GiveAllItems();
+        gSave.stats.equipped[SLOT_A] = ITEM_REMOTE_BOMBS;
+        gSave.stats.equipped[SLOT_B] = ITEM_REMOTE_BOMBS;
+        setup = 1;
+        walk_from = (int)frame + 30;
+        fprintf(stderr, "[roll-macro-test] frame %u: items granted; A=B=Remote Bombs (sword=%d); walk at %d\n",
+                frame, (int)ItemIsSword(gSave.stats.equipped[SLOT_B]), walk_from);
+    }
+
+    /* Keep PL_NO_CAP cleared so PlayerRollInit picks ANIM_ROLL (real post-Ezlo
+     * roll with the frame&0x40 item window), not the intro-only ANIM_ROLL_NOCAP. */
+    if (setup && !observe_until) {
+        gPlayerState.flags &= ~PL_NO_CAP;
+    }
+
+    /* Hold UP until Link is actually walking and R's context-action is roll,
+     * then stamp the ROLL_ATTACK bind on that frame (documented usage). */
+    if (setup && walk_from && (int)frame >= walk_from && !fired) {
+        Port_Config_TestForceEdge(PORT_INPUT_UP);
+        if (gPlayerState.framestate == PL_STATE_WALK &&
+            gHUD.rActionInteractObject == R_ACTION_ROLL &&
+            !(gPlayerState.flags & PL_ROLLING)) {
+            Port_Config_TestForceEdge(PORT_INPUT_ROLL_ATTACK);
+            fired = 1;
+            observe_until = (int)frame + 90;
+            fprintf(stderr, "[roll-macro-test] frame %u: FIRE (walking; rAction=ROLL; +ROLL_ATTACK)\n", frame);
+        } else if ((int)frame > walk_from + 120) {
+            fprintf(stderr, "[roll-macro-test] frame %u: never reached WALK+ROLL (fs=%u rAction=%u) -> FAIL\n",
+                    frame, (unsigned)gPlayerState.framestate, (unsigned)gHUD.rActionInteractObject);
+            fflush(stderr);
+            _Exit(1);
+        }
+    }
+
+    if (observe_until) {
+        if (gPlayerState.flags & PL_ROLLING)
+            saw_rolling = 1;
+        if (gPlayerEntity.base.action == PLAYER_ROLL && (gPlayerEntity.base.frame & 0x40))
+            saw_window = 1;
+        if ((int)gPlayerState.attack_status > best_attack)
+            best_attack = (int)gPlayerState.attack_status;
+        if (gPlayerState.lastSwordMove == SWORD_MOVE_ROLL)
+            saw_roll_move = 1;
+
+        if ((int)frame >= observe_until) {
+            int b_is_sword = (int)ItemIsSword(gSave.stats.equipped[SLOT_B]);
+            int pass = saw_rolling && saw_window && saw_roll_move && (best_attack != 0) && !b_is_sword;
+            fprintf(stderr,
+                    "[roll-macro-test] RESULT: rolling=%d window=%d roll_sword_move=%d attack_peak=%d "
+                    "B_equip=0x%02x(sword=%d) -> %s\n",
+                    saw_rolling, saw_window, saw_roll_move, best_attack,
+                    (unsigned)gSave.stats.equipped[SLOT_B], b_is_sword, pass ? "PASS" : "FAIL");
+            fflush(stderr);
+            _Exit(pass ? 0 : 1);
+        }
+    }
+
+    if (frame == 8000) {
+        fprintf(stderr, "[roll-macro-test] timeout booted=%d warped=%d setup=%d fired=%d task=%u\n",
+                booted, warped, setup, fired, (unsigned)gMain.task);
+        fflush(stderr);
+        _Exit(3);
+    }
+}

--- a/port/port_roll_attack_macro.c
+++ b/port/port_roll_attack_macro.c
@@ -1,0 +1,318 @@
+/*
+ * port_roll_attack_macro.c — one-button start-of-roll attack.
+ *
+ * Sequence (frame-perfect inside the port loop):
+ *   1. Player holds a direction and presses the roll-attack bind (default D).
+ *   2. Inject R + direction until PL_ROLLING is set.
+ *   3. Wait until the roll animation reaches the item-use window
+ *      (gPlayerEntity.base.frame & 0x40 — same gate PlayerRollUpdate uses
+ *      before calling UpdateActiveItems).
+ *   4. Inject a fresh B press with the best owned sword equipped virtually.
+ *
+ * If the animation window is missed, fall back to alternating B pulses for a
+ * few frames while still rolling (covers edge timing / late detection).
+ */
+
+#include "port_roll_attack_macro.h"
+#include "port_runtime_config.h"
+
+#include "gba/io_reg.h"
+#include "global.h"
+#include "item.h"
+#include "player.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef enum {
+    MACRO_IDLE = 0,
+    MACRO_ROLL,
+    MACRO_WAIT_ITEM_FRAME,
+    MACRO_ATTACK,
+    MACRO_ATTACK_PULSE,
+} MacroPhase;
+
+static MacroPhase sPhase = MACRO_IDLE;
+static uint16_t sDirMask = 0;
+static int sWaitFrames = 0;
+static int sPulseFrames = 0;
+static bool sSwordOverride = false;
+static bool sBPulseHigh = false;
+static bool sBFired = false;
+static u8 sAttackStatusBaseline = 0;
+static u32 sFlagsBaseline = 0;
+
+static const uint8_t kSwordPriority[] = {
+    ITEM_FOURSWORD,
+    ITEM_BLUE_SWORD,
+    ITEM_RED_SWORD,
+    ITEM_GREEN_SWORD,
+    ITEM_SMITH_SWORD,
+};
+
+static bool RollMacroDebug(void) {
+    static int sCached = -1;
+    if (sCached < 0) {
+        const char* e = getenv("TMC_ROLL_MACRO_DEBUG");
+        sCached = (e && e[0] == '1') ? 1 : 0;
+    }
+    return sCached != 0;
+}
+
+static uint8_t BestOwnedSword(void) {
+    for (size_t i = 0; i < sizeof(kSwordPriority) / sizeof(kSwordPriority[0]); i++) {
+        if (GetInventoryValue(kSwordPriority[i]) != 0) {
+            return kSwordPriority[i];
+        }
+    }
+    return 0;
+}
+
+static uint16_t ResolveDirectionMask(void) {
+    uint16_t mask = 0;
+
+    if (Port_Config_InputPressed(PORT_INPUT_UP)) {
+        mask |= DPAD_UP;
+    } else if (Port_Config_InputPressed(PORT_INPUT_DOWN)) {
+        mask |= DPAD_DOWN;
+    }
+    if (Port_Config_InputPressed(PORT_INPUT_LEFT)) {
+        mask |= DPAD_LEFT;
+    } else if (Port_Config_InputPressed(PORT_INPUT_RIGHT)) {
+        mask |= DPAD_RIGHT;
+    }
+    if (mask != 0) {
+        return mask;
+    }
+
+    float sx = 0.f, sy = 0.f;
+    if (!Port_Config_GetLeftStick(&sx, &sy)) {
+        return 0;
+    }
+
+    const float dz = Port_Config_GetAnalogDeadzone();
+    if ((sx * sx + sy * sy) < dz * dz) {
+        return 0;
+    }
+
+    if (fabsf(sx) >= fabsf(sy)) {
+        return (sx < 0.f) ? DPAD_LEFT : DPAD_RIGHT;
+    }
+    return (sy < 0.f) ? DPAD_UP : DPAD_DOWN;
+}
+
+static bool CanStartMacro(void) {
+    if (!Port_Config_GetRollAttackMacroEnabled()) {
+        return false;
+    }
+    if (sPhase != MACRO_IDLE) {
+        return false;
+    }
+    if (gPlayerState.controlMode != CONTROL_ENABLED) {
+        return false;
+    }
+    if (gPlayerState.flags & (PL_ROLLING | PL_CAPTURED | PL_DISABLE_ITEMS | PL_BUSY)) {
+        return false;
+    }
+    if ((gPlayerState.skills & SKILL_ROLL_ATTACK) == 0) {
+        return false;
+    }
+    if (BestOwnedSword() == 0) {
+        return false;
+    }
+    if (ResolveDirectionMask() == 0) {
+        return false;
+    }
+    return true;
+}
+
+static bool RollItemFrameOpen(void) {
+    return gPlayerEntity.base.action == PLAYER_ROLL && (gPlayerEntity.base.frame & 0x40) != 0;
+}
+
+static void ReleaseMacroButtons(uint16_t* keyinput) {
+    *keyinput |= (uint16_t)(R_BUTTON | B_BUTTON | DPAD_UP | DPAD_DOWN | DPAD_LEFT | DPAD_RIGHT);
+}
+
+static void InjectDirection(uint16_t* keyinput) {
+    if (sDirMask != 0) {
+        *keyinput &= ~sDirMask;
+    }
+}
+
+static void FinishMacro(void) {
+    sPhase = MACRO_IDLE;
+    sDirMask = 0;
+    sSwordOverride = false;
+    sBPulseHigh = false;
+    sBFired = false;
+    sWaitFrames = 0;
+    sPulseFrames = 0;
+}
+
+static void InjectBPress(uint16_t* keyinput) {
+    *keyinput &= ~B_BUTTON;
+    sSwordOverride = true;
+    sBFired = true;
+}
+
+/* Only treat a roll attack as success after *this* macro fired B.
+ * lastSwordMove stays SWORD_MOVE_ROLL across attacks, so it cannot be
+ * used alone or the second press exits during WAIT without sending B. */
+static bool MacroAttackLanded(void) {
+    if (!sBFired) {
+        return false;
+    }
+    if ((gPlayerState.attack_status & 0xf) != 0 &&
+        gPlayerState.attack_status != sAttackStatusBaseline) {
+        return true;
+    }
+    if ((gPlayerState.flags & PL_SWORD_THRUST) && !(sFlagsBaseline & PL_SWORD_THRUST)) {
+        return true;
+    }
+    return false;
+}
+
+void Port_RollAttackMacro_Tick(uint16_t* keyinput) {
+    if (!keyinput) {
+        return;
+    }
+
+    if (!Port_Config_GetRollAttackMacroEnabled()) {
+        if (sPhase != MACRO_IDLE) {
+            FinishMacro();
+        }
+        return;
+    }
+
+    if (sPhase == MACRO_IDLE) {
+        if (Port_Config_InputEdgePressed(PORT_INPUT_ROLL_ATTACK) && CanStartMacro()) {
+            sDirMask = ResolveDirectionMask();
+            sPhase = MACRO_ROLL;
+            sWaitFrames = 0;
+            sPulseFrames = 0;
+            sSwordOverride = false;
+            sBPulseHigh = false;
+            sBFired = false;
+            sAttackStatusBaseline = gPlayerState.attack_status;
+            sFlagsBaseline = gPlayerState.flags;
+            if (RollMacroDebug()) {
+                fprintf(stderr, "[roll-macro] start dir=0x%04x\n", sDirMask);
+            }
+        } else {
+            return;
+        }
+    }
+
+    /* While the macro runs, mask physical R/B/d-pad so we own the sequence. */
+    ReleaseMacroButtons(keyinput);
+    InjectDirection(keyinput);
+
+    if (!(gPlayerState.flags & PL_ROLLING) && sPhase != MACRO_ROLL && !MacroAttackLanded()) {
+        if (RollMacroDebug()) {
+            fprintf(stderr, "[roll-macro] abort — roll ended before attack\n");
+        }
+        FinishMacro();
+        return;
+    }
+
+    switch (sPhase) {
+        case MACRO_ROLL:
+            if (!(gPlayerState.flags & PL_ROLLING)) {
+                *keyinput &= ~R_BUTTON;
+            } else {
+                sPhase = MACRO_WAIT_ITEM_FRAME;
+                sWaitFrames = 0;
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] PL_ROLLING — waiting for frame&0x40\n");
+                }
+            }
+            if (++sWaitFrames > 15) {
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] timeout waiting for roll\n");
+                }
+                FinishMacro();
+            }
+            break;
+
+        case MACRO_WAIT_ITEM_FRAME:
+            /* Keep direction held; leave B released so the next press is a new edge. */
+            if (RollItemFrameOpen()) {
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] frame window open — firing B\n");
+                }
+                InjectBPress(keyinput);
+                sPhase = MACRO_ATTACK;
+                sWaitFrames = 0;
+                break;
+            }
+            if (++sWaitFrames > 20) {
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] window miss — pulse fallback\n");
+                }
+                sPhase = MACRO_ATTACK_PULSE;
+                sPulseFrames = 0;
+                sBPulseHigh = true;
+            }
+            break;
+
+        case MACRO_ATTACK:
+            if (MacroAttackLanded()) {
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] success\n");
+                }
+                FinishMacro();
+                break;
+            }
+            /* Hold sword override briefly in case the item spawns next frame. */
+            if (++sWaitFrames <= 2) {
+                sSwordOverride = true;
+            } else {
+                sPhase = MACRO_ATTACK_PULSE;
+                sPulseFrames = 0;
+                sBPulseHigh = false;
+            }
+            break;
+
+        case MACRO_ATTACK_PULSE:
+            if (MacroAttackLanded()) {
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] success (pulse)\n");
+                }
+                FinishMacro();
+                break;
+            }
+            if (!(gPlayerState.flags & PL_ROLLING) || ++sPulseFrames > 16) {
+                if (RollMacroDebug()) {
+                    fprintf(stderr, "[roll-macro] pulse gave up\n");
+                }
+                FinishMacro();
+                break;
+            }
+            if (sBPulseHigh) {
+                InjectBPress(keyinput);
+            } else {
+                sSwordOverride = false;
+            }
+            sBPulseHigh = !sBPulseHigh;
+            break;
+
+        default:
+            FinishMacro();
+            break;
+    }
+}
+
+bool Port_RollAttackMacro_IsBHeld(void) {
+    return sSwordOverride;
+}
+
+uint8_t Port_RollAttackMacro_GetEffectiveBItem(uint8_t saved) {
+    if (!sSwordOverride) {
+        return saved;
+    }
+    uint8_t sword = BestOwnedSword();
+    return sword ? sword : saved;
+}

--- a/port/port_roll_attack_macro.h
+++ b/port/port_roll_attack_macro.h
@@ -1,0 +1,33 @@
+#ifndef PORT_ROLL_ATTACK_MACRO_H
+#define PORT_ROLL_ATTACK_MACRO_H
+
+/*
+ * One-button roll attack (start-of-roll timing).
+ *
+ * Bound to PORT_INPUT_ROLL_ATTACK (default: keyboard D). While holding a
+ * direction, a press injects R + direction, then B with the best owned sword
+ * — regardless of what is equipped in A/B slots.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Called once per frame from Port_UpdateInput after real inputs are read.
+ * May override KEYINPUT bits for R / B / direction during the sequence. */
+void Port_RollAttackMacro_Tick(uint16_t* keyinput);
+
+/* True on frames where the macro is injecting a sword press through B. */
+bool Port_RollAttackMacro_IsBHeld(void);
+
+/* Returns the best owned sword while IsBHeld(), else `saved`. */
+uint8_t Port_RollAttackMacro_GetEffectiveBItem(uint8_t saved);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/port/port_runtime_config.cpp
+++ b/port/port_runtime_config.cpp
@@ -50,6 +50,9 @@ const std::array<Def, PORT_INPUT_COUNT> kDefaults = {{
     { PORT_INPUT_SOFT_Y,  "soft_y",  { "SDLK:0x00000076", "SDL_GAMEPAD:0x00000003" } },
     { PORT_INPUT_SOFT_L2, "soft_l2", { "SDLK:0x00000071", "SDL_AXIS:0x00000004" } },
     { PORT_INPUT_SOFT_R2, "soft_r2", { "SDLK:0x00000065", "SDL_AXIS:0x00000005" } },
+    /* Roll attack: keyboard D + R3 (right stick click). R3 is unused by the
+     * base game and sits near the movement stick for a direction+macro press. */
+    { PORT_INPUT_ROLL_ATTACK, "roll_attack", { "SDLK:0x00000064", "SDL_GAMEPAD:0x00000008" } },
 }};
 
 u8 sScale = 3;
@@ -117,6 +120,7 @@ float       sLcdPersistRho = 0.35f;    /* persistence: fraction of prev frame ke
 bool        sRibbonCfg     = true;     /* F8 menu style: ribbon (true) vs classic */
 float       sMasterVolume  = 1.0f;     /* game master volume [0,1]; 1.0 = unchanged */
 bool        sHoldAdvanceText = false;  /* hold an advance key to keep paging text */
+bool        sRollAttackMacroEnabled = true;
 bool        sFullscreen    = false;
 bool        sFullscreenHideCursor = true; /* hide the OS cursor while fullscreen */
 float       sAnalogDeadzone = 0.30f;   /* 360° stick deadzone magnitude [0..0.95] */
@@ -199,6 +203,7 @@ const BoolCfg kBoolCfg[] = {
     { "lcd_persistence",       &sLcdPersist,              false },
     { "ribbon_mode",           &sRibbonCfg,               true  },
     { "hold_advance_text",     &sHoldAdvanceText,         false },
+    { "roll_attack_macro",     &sRollAttackMacroEnabled,  true  },
     { "fullscreen",            &sFullscreen,              false },
     { "fullscreen_hide_cursor",&sFullscreenHideCursor,    true  },
     { "rando_enabled",         &sRandoEnabled,            false },
@@ -365,6 +370,7 @@ extern "C" const char* Port_Config_InputUiLabel(PortInput input) {
         "Soft slot Y",
         "Soft slot L2 / LT",
         "Soft slot R2 / RT",
+        "Roll attack",
     };
     if (input < 0 || input >= PORT_INPUT_COUNT) {
         return "?";
@@ -1436,6 +1442,8 @@ extern "C" bool Port_Config_GetRibbonEnabled(void) { return sRibbonCfg; }
 extern "C" void Port_Config_SetRibbonEnabled(bool on) { sRibbonCfg = on; sConfigJson["ribbon_mode"] = on; SaveConfig(); }
 extern "C" bool Port_Config_GetHoldToAdvanceText(void) { return sHoldAdvanceText; }
 extern "C" void Port_Config_SetHoldToAdvanceText(bool on) { sHoldAdvanceText = on; sConfigJson["hold_advance_text"] = on; SaveConfig(); }
+extern "C" bool Port_Config_GetRollAttackMacroEnabled(void) { return sRollAttackMacroEnabled; }
+extern "C" void Port_Config_SetRollAttackMacroEnabled(bool on) { sRollAttackMacroEnabled = on; sConfigJson["roll_attack_macro"] = on; SaveConfig(); }
 extern "C" float Port_Config_GetMasterVolume(void) { return sMasterVolume; }
 extern "C" void Port_Config_SetMasterVolume(float v) { if (v < 0.0f) v = 0.0f; if (v > 1.0f) v = 1.0f; sMasterVolume = v; sConfigJson["master_volume"] = (double)v; SaveConfig(); }
 extern "C" bool Port_Config_GetFullscreen(void) { return sFullscreen; }

--- a/port/port_runtime_config.cpp
+++ b/port/port_runtime_config.cpp
@@ -1122,6 +1122,18 @@ extern "C" void Port_Config_ClearInputEdges(void) {
     sEdgePressed.fill(false);
 }
 
+/* Test-only input seam. Stamps the per-frame edge cache for `input` exactly
+ * as an SDL KEY_DOWN would, so headless repro harnesses (see
+ * port_repro_roll_macro.c) drive edge/held reads through the real
+ * Port_Config_InputPressed / Port_Config_InputEdgePressed path. Wiped every
+ * frame by Port_Config_ClearInputEdges() after KEYINPUT is committed, so a
+ * forced bit never survives past the frame it is set on. */
+extern "C" void Port_Config_TestForceEdge(PortInput input) {
+    if (input >= 0 && input < PORT_INPUT_COUNT) {
+        sEdgePressed[input] = true;
+    }
+}
+
 extern "C" bool Port_Config_InputEdgePressed(PortInput input) {
     /* Parity mode disables the sub-frame edge cache: a press is only seen
      * on the frame the engine actually polls it, matching hardware 1-frame

--- a/port/port_runtime_config.h
+++ b/port/port_runtime_config.h
@@ -29,6 +29,8 @@ typedef enum {
     PORT_INPUT_SOFT_Y,
     PORT_INPUT_SOFT_L2,
     PORT_INPUT_SOFT_R2,
+    /* One-button roll attack (port_roll_attack_macro.c). Default keyboard D. */
+    PORT_INPUT_ROLL_ATTACK,
     PORT_INPUT_COUNT,
 } PortInput;
 
@@ -194,6 +196,8 @@ bool        Port_Config_GetRibbonEnabled(void);
 void        Port_Config_SetRibbonEnabled(bool on);
 bool        Port_Config_GetHoldToAdvanceText(void);
 void        Port_Config_SetHoldToAdvanceText(bool on);
+bool        Port_Config_GetRollAttackMacroEnabled(void);
+void        Port_Config_SetRollAttackMacroEnabled(bool on);
 float       Port_Config_GetMasterVolume(void);
 void        Port_Config_SetMasterVolume(float v);
 bool        Port_Config_GetFullscreen(void);

--- a/port/port_runtime_config.h
+++ b/port/port_runtime_config.h
@@ -268,6 +268,12 @@ void  Port_Config_SetAnalogDeadzone(float v);
  * frame's polled state isn't stuck reporting the previous tap. */
 void Port_Config_ClearInputEdges(void);
 
+/* Test-only: stamp the per-frame edge cache for `input` (see
+ * Port_Config_TestForceEdge in the .cpp). Used exclusively by env-gated
+ * repro harnesses; the bit is wiped by Port_Config_ClearInputEdges() each
+ * frame, so it never persists into normal play. */
+void Port_Config_TestForceEdge(PortInput input);
+
 int  Port_Config_PreferredRegion(void);
 void Port_Config_SetPreferredRegion(int region);
 int  Port_Config_PreferredLanguage(void);

--- a/src/itemUtils.c
+++ b/src/itemUtils.c
@@ -20,6 +20,7 @@
 
 #ifdef PC_PORT
 #include "port_softslots.h"
+#include "port_roll_attack_macro.h"
 #endif
 
 const Wallet gWalletSizes[] = {
@@ -289,6 +290,9 @@ EquipSlot IsItemEquipped(u32 itemId) {
      * item, report it as B-equipped so held-item code paths (lantern stay-
      * lit, magic boomerang return, gust-jar charge) behave normally. */
     if (Port_SoftSlots_IsBHeld() && Port_SoftSlots_GetEffectiveBItem(0xFF) == itemId) {
+        return EQUIP_SLOT_B;
+    }
+    if (Port_RollAttackMacro_IsBHeld() && Port_RollAttackMacro_GetEffectiveBItem(0xFF) == itemId) {
         return EQUIP_SLOT_B;
     }
 #endif

--- a/src/player.c
+++ b/src/player.c
@@ -31,6 +31,7 @@
 #include "port_scripts.h"
 #ifdef PC_PORT
 #include "port_softslots.h"
+#include "port_roll_attack_macro.h"
 #endif
 #include "save.h"
 #include "scroll.h"
@@ -3623,6 +3624,7 @@ void SurfaceAction_CloneTile(PlayerEntity* this) {
              * result stays a sword, preserving the GBA item domain. */
             {
                 u32 eff = Port_SoftSlots_GetEffectiveBItem(item);
+                eff = Port_RollAttackMacro_GetEffectiveBItem((u8)eff);
                 if (ItemIsSword(eff))
                     item = eff;
             }

--- a/src/playerUtils.c
+++ b/src/playerUtils.c
@@ -31,7 +31,13 @@
 #include "port_gba_mem.h"
 #include "port_rom.h"
 #include "port_softslots.h"
+#include "port_roll_attack_macro.h"
 #include <string.h>
+
+static u32 Port_PcEffectiveBItem(u32 bItem) {
+    bItem = Port_SoftSlots_GetEffectiveBItem((u8)bItem);
+    return Port_RollAttackMacro_GetEffectiveBItem((u8)bItem);
+}
 #endif
 
 static void sub_08077E54(ItemBehavior* beh);
@@ -230,7 +236,7 @@ void UpdateActiveItems(PlayerEntity* this) {
 #ifdef PC_PORT
         /* Soft-slots (X/Y/L2/R2) override the B-equipped item without
          * mutating gSave. See port/port_softslots.h. */
-        bItem = Port_SoftSlots_GetEffectiveBItem((u8)bItem);
+        bItem = Port_PcEffectiveBItem(bItem);
         /* Optional L-modifier: while L is held, A and B instead fire the
          * items bound to the port's two soft slots (assigned via SELECT-
          * hold in the pause menu). An unbound soft slot falls back to the
@@ -731,6 +737,9 @@ bool32 IsItemActiveByInput(ItemBehavior* this, PlayerInputState input) {
     if (Port_SoftSlots_IsBHeld() && Port_SoftSlots_GetEffectiveBItem(0xFF) == id) {
         return (INPUT_USE_ITEM2 & input) ? TRUE : FALSE;
     }
+    if (Port_RollAttackMacro_IsBHeld() && Port_RollAttackMacro_GetEffectiveBItem(0xFF) == id) {
+        return (INPUT_USE_ITEM2 & input) ? TRUE : FALSE;
+    }
 #endif
     if (stats->equipped[SLOT_A] == id) {
         val = INPUT_USE_ITEM1;
@@ -1046,7 +1055,7 @@ bool32 sub_08078008(ChargeState* state) {
     } else {
         u32 bItem = gSave.stats.equipped[SLOT_B];
 #ifdef PC_PORT
-        bItem = Port_SoftSlots_GetEffectiveBItem(bItem);
+        bItem = Port_PcEffectiveBItem(bItem);
 #endif
         if (ItemIsSword(bItem) != ITEM_NONE) {
             swordType = bItem;
@@ -2757,7 +2766,7 @@ bool32 HasSwordEquipped(void) {
     } else {
         u32 bItem = gSave.stats.equipped[SLOT_B];
 #ifdef PC_PORT
-        bItem = Port_SoftSlots_GetEffectiveBItem(bItem);
+        bItem = Port_PcEffectiveBItem(bItem);
 #endif
         return ItemIsSword(bItem);
     }

--- a/xmake.lua
+++ b/xmake.lua
@@ -685,6 +685,7 @@ target("tmc_pc")
     add_files("port/port_repro_rando.c")
     add_files("port/port_repro_a11y.c")
     add_files("port/port_repro_roomcap.c")  -- generic in-game room capture (TMC_ROOMCAP)
+    add_files("port/port_repro_roll_macro.c") -- roll-attack macro e2e test (TMC_REPRO_ROLL_MACRO)
     -- Link the asset extractor implementation directly so tmc_pc can
     -- run extraction in-process at startup (no shell-out) and share
     -- the engine's already-loaded ROM buffer.

--- a/xmake.lua
+++ b/xmake.lua
@@ -740,6 +740,7 @@ target("tmc_pc")
     add_files("port/port_upscale.c") -- xBRZ-style pixel-art upscaler
     add_files("port/port_save.c")        -- EEPROM save emulation
     add_files("port/port_softslots.c")   -- Extra item-equip buttons (X/Y/L2/R2)
+    add_files("port/port_roll_attack_macro.c") -- One-button roll attack (default: D)
     add_files("port/port_touch_controls.cpp")
     add_files("port/port_filter.c")      -- CRT/LCD post-process filters
     add_files("port/port_animation.c")   -- Animation system (ported from ASM)


### PR DESCRIPTION
## Summary
- One-button **start-of-roll attack**: hold direction + press bind (default **D** / **R3** right-stick click).
- Uses your **best owned sword** via the same virtual B-item pattern as soft slots — A/B equip unchanged.
- Input injection is timed to `PlayerRollUpdate`'s `frame & 0x40` window (when `UpdateActiveItems` runs during a roll).
- Toggle in **F8 → Controls** (`roll_attack_macro` in config.json); rebindable there.

## Test plan
- [ ] Learn Roll Attack from Grayblade; equip non-sword items on A/B.
- [ ] Keyboard: hold direction + **D** → roll attack each time (not just the first).
- [ ] Gamepad: hold direction + **R3** → same.
- [ ] Toggle off in F8 → Controls → macro does nothing.
- [ ] Rebind to another key/button and confirm it still works.