### PR TITLE
Feature: assign softslot items from pause menu

### DIFF
--- a/port/port_softslots.c
+++ b/port/port_softslots.c
@@ -109,6 +109,10 @@ bool Port_SoftSlots_IsBHeld(void) {
     return sActiveSlot >= 0;
 }
 
+int Port_SoftSlots_GetActiveSlot(void) {
+    return sActiveSlot;
+}
+
 uint8_t Port_SoftSlots_GetEffectiveBItem(uint8_t saved) {
     if (sActiveSlot < 0) return saved;
     uint8_t a = sAssignments[sActiveSlot];

--- a/port/port_softslots.h
+++ b/port/port_softslots.h
@@ -32,6 +32,7 @@ void Port_SoftSlots_Update(void);
  * input layer ORs B_BUTTON into KEYINPUT in this case so the engine sees
  * a regular B-press and routes it through CreateItemIfInputMatches. */
 bool Port_SoftSlots_IsBHeld(void);
+int Port_SoftSlots_GetActiveSlot(void);
 
 /* Returns the soft-slot's item if a slot is active, else `saved`. Used by
  * src/playerUtils.c at the B-dispatch site to override the effective

--- a/src/menu/pauseMenu.c
+++ b/src/menu/pauseMenu.c
@@ -444,6 +444,15 @@ void PauseMenu_ItemMenu_Update(void) {
                             SoundReq(SFX_TEXTBOX_SELECT);
                             break;
                         }
+
+                        /*works only if pressed softslot was
+                        equipped with anything from debug menu
+                        since requires sActiveSlot to be non -1*/
+                        if(Port_SoftSlots_IsBHeld()){
+                            Port_SoftSlots_SetAssignment(Port_SoftSlots_GetActiveSlot(), (unsigned char)gPauseMenu.items[menuSlot]);
+                            SoundReq(SFX_TEXTBOX_SELECT);
+                            break;
+                        }
                     }
 #endif
                     ForceEquipItem(gPauseMenu.items[menuSlot], slot);

--- a/src/menu/pauseMenu.c
+++ b/src/menu/pauseMenu.c
@@ -444,6 +444,15 @@ void PauseMenu_ItemMenu_Update(void) {
                             SoundReq(SFX_TEXTBOX_SELECT);
                             break;
                         }
+
+                         /*works only if pressed softslot was
+                        equipped with anything from debug menu
+                        since requires sActiveSlot to be non -1*/
+                        if(Port_SoftSlots_IsBHeld()){
+                            Port_SoftSlots_SetAssignment(Port_SoftSlots_GetActiveSlot(), (unsigned char)gPauseMenu.items[menuSlot]);
+                            SoundReq(SFX_TEXTBOX_SELECT);
+                            break;
+                        }
                     }
 #endif
                     ForceEquipItem(gPauseMenu.items[menuSlot], slot);


### PR DESCRIPTION
Summary: 

* Allows to change softslot menu item from pause menu, just like A\B items
* Gets activeslot (hence slot should be occupied by another item, not "not equipped" -1) and sets menu item to that