### PR TITLE
fix(region): centralize save language slots

### DIFF
--- a/include/main.h
+++ b/include/main.h
@@ -7,6 +7,7 @@
 #include "screen.h"
 #include "script.h"
 #include "structures.h"
+#include "region.h"
 
 /** File signature */
 #define SIGNATURE 'MCZ3'
@@ -28,6 +29,15 @@ typedef enum {
     NUM_LANGUAGES,
 } Language;
 
+/*
+ * EU stores its language-gated save-header resources in slots 2..6. Slot 2 is
+ * English, then FR/DE/ES/IT follow. USA and JP use the public Language enum
+ * directly.
+ */
+#define EU_LANGUAGE_EN_SLOT LANGUAGE_FR
+#define EU_LANGUAGE_LAST_SLOT NUM_LANGUAGES
+#define LANGUAGE_SLOT_COUNT (NUM_LANGUAGES + 1)
+
 #ifdef MULTI_REGION
 /* Fat binary is compiled USA/EU-baseline; GAME_LANGUAGE is the compile-time
  * default (English) used in the static sDefaultSettings initializer and as a
@@ -41,6 +51,49 @@ typedef enum {
 #define GAME_LANGUAGE LANGUAGE_JP
 #endif
 #endif
+
+static inline u32 RegionLanguageSlotCount(void) {
+    return REGION_IS_EU ? LANGUAGE_SLOT_COUNT : NUM_LANGUAGES;
+}
+
+static inline u8 RegionDefaultLanguage(void) {
+    if (REGION_IS_JP) {
+        return LANGUAGE_JP;
+    }
+    if (REGION_IS_EU) {
+        return EU_LANGUAGE_EN_SLOT;
+    }
+    return GAME_LANGUAGE;
+}
+
+static inline s32 RegionPreferredLanguageToSaveSlot(s32 language) {
+    if (language < 0) {
+        return -1;
+    }
+    if (REGION_IS_JP) {
+        return LANGUAGE_JP;
+    }
+    if (REGION_IS_EU) {
+        if (language <= LANGUAGE_EN) {
+            return EU_LANGUAGE_EN_SLOT;
+        }
+        if (language < NUM_LANGUAGES) {
+            return language + 1;
+        }
+        return -1;
+    }
+    return language < NUM_LANGUAGES ? language : -1;
+}
+
+static inline bool32 RegionSaveLanguageValid(u32 language) {
+    if (REGION_IS_JP) {
+        return language == LANGUAGE_JP;
+    }
+    if (REGION_IS_EU) {
+        return language >= EU_LANGUAGE_EN_SLOT && language <= EU_LANGUAGE_LAST_SLOT;
+    }
+    return language == GAME_LANGUAGE;
+}
 
 /** Program tasks. */
 typedef enum {

--- a/port/port_rom.c
+++ b/port/port_rom.c
@@ -1829,15 +1829,17 @@ void Port_ApplyLanguage(void) {
     if (lang < 0) {
         sLastAppliedPref = lang;
         const int current = gSaveHeader->language;
-        if (current >= 0 && current < 6 /* NUM_LANGUAGES */ && gTranslations[current] != NULL) {
+        if (current >= 0 && current < (int)RegionLanguageSlotCount() && gTranslations[current] != NULL &&
+            RegionSaveLanguageValid((u32)current)) {
             return;
         }
-        lang = REGION_IS_JP ? 0 /* LANGUAGE_JP */ : 1 /* LANGUAGE_EN */;
+        lang = RegionDefaultLanguage();
     } else {
         sLastAppliedPref = lang;
+        lang = RegionPreferredLanguageToSaveSlot(lang);
     }
 
-    if (lang >= 0 && lang < 6 /* NUM_LANGUAGES */ && gTranslations[lang] != NULL) {
+    if (lang >= 0 && lang < (int)RegionLanguageSlotCount() && gTranslations[lang] != NULL) {
         gSaveHeader->language = (u8)lang;
     }
 }

--- a/port/port_rom.c
+++ b/port/port_rom.c
@@ -15,6 +15,7 @@
 #include "port_runtime_config.h"
 #include "port_gba_mem.h"
 #include "structures.h"
+#include "main.h"
 #include "tileMap.h"
 #ifndef TMC_N64
 #include <SDL3/SDL.h>

--- a/src/main.c
+++ b/src/main.c
@@ -238,11 +238,7 @@ void InitSaveHeader(void) {
             case -1:
             default:
                 MemCopy(&sDefaultSettings, gSaveHeader, sizeof(SaveHeader));
-                if (REGION_IS_JP) {
-                    gSaveHeader->language = LANGUAGE_JP;
-                } else if (REGION_IS_EU) {
-                    gSaveHeader->language = 2; // TODO in EU 2 is english?
-                }
+                gSaveHeader->language = RegionDefaultLanguage();
                 WriteSaveHeader(gSaveHeader);
                 break;
         }
@@ -270,15 +266,10 @@ void InitSaveHeader(void) {
         (gSaveHeader->msg_speed >= MAX_MSG_SPEED) ||
         (gSaveHeader->brightness >= MAX_BRIGHTNESS)
         /* The multi-region binary is compiled USA-baseline (GAME_LANGUAGE == EN),
-         * but the loaded ROM's region is only known at runtime. A JP ROM is
-         * Japanese-only: its language-conditional gfx (title, name-entry,
-         * file-select) key off language == 0, so a save still flagged English
-         * (e.g. a USA tmc.sav) loads English gfx the JP ROM lacks. Require JP
-         * language on a JP ROM so an English-flagged header is reset to
-         * LANGUAGE_JP by InitSaveHeader's default path. */
-        || (REGION_IS_EU   ? ((gSaveHeader->language <= GAME_LANGUAGE) || (gSaveHeader->language > NUM_LANGUAGES))
-            : REGION_IS_JP ? (gSaveHeader->language != LANGUAGE_JP)
-                           : (gSaveHeader->language != GAME_LANGUAGE)) ||
+         * but the loaded ROM's region is only known at runtime. Region-specific
+         * language-gated gfx (title, name-entry, file-select) must use the active
+         * ROM's save-header slots: JP=0, USA=1, EU=2..6. */
+        || !RegionSaveLanguageValid(gSaveHeader->language) ||
         (gSaveHeader->invalid))
         return FALSE;
 

--- a/src/text.c
+++ b/src/text.c
@@ -117,9 +117,9 @@ void sub_0805EEB4(Token* token, u32 textIndex) {
     token->textIndex = (u16)textIndex;
     langIndex = gSaveHeader->language;
 #ifdef PC_PORT
-    if (langIndex >= NUM_LANGUAGES || gTranslations[langIndex] == NULL) {
-        langIndex = REGION_IS_JP ? LANGUAGE_JP : LANGUAGE_EN;
-        if (langIndex >= NUM_LANGUAGES || gTranslations[langIndex] == NULL) {
+    if (langIndex >= RegionLanguageSlotCount() || gTranslations[langIndex] == NULL) {
+        langIndex = RegionDefaultLanguage();
+        if (langIndex >= RegionLanguageSlotCount() || gTranslations[langIndex] == NULL) {
             langIndex = GAME_LANGUAGE;
         }
     }
@@ -403,9 +403,9 @@ u32* sub_0805F25C(u32 param_1) {
     u32 lang = gSaveHeader->language;
 
 #ifdef PC_PORT
-    if (lang >= NUM_LANGUAGES || gTranslations[lang] == NULL) {
-        lang = REGION_IS_JP ? LANGUAGE_JP : LANGUAGE_EN;
-        if (lang >= NUM_LANGUAGES || gTranslations[lang] == NULL) {
+    if (lang >= RegionLanguageSlotCount() || gTranslations[lang] == NULL) {
+        lang = RegionDefaultLanguage();
+        if (lang >= RegionLanguageSlotCount() || gTranslations[lang] == NULL) {
             lang = GAME_LANGUAGE;
         }
     }


### PR DESCRIPTION
## Summary
- centralize region-specific save-header language slot handling
- make EU English explicitly use save slot 2 and accept EU slots 2..6
- route text and preferred-language fallbacks through the same region helpers

## Notes
The current upstream already has multi-region ROM detection/support. This PR tightens the EU language-slot edge inside that support instead of reintroducing a larger region porting patch.

## Testing
- git diff --check
- Attempted `python3 build.py --usa --slim`, but local build setup stopped before compilation because `libpng`, `fmt`, and `nlohmann-json` are missing locally; optional private submodules were also unavailable/skipped by the build helper.