### PR TITLE
fix: port audited gameplay fixes from the 3DS fork

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -12,6 +12,7 @@ extern void EnableRandomDrops(void);
 extern u32 IsMinishItem(u32);
 
 void CreateItemEntity(u32, u32, u32);
+bool32 CreateItemEntityWithFlag(u32, u32, u32, u16);
 extern void ExecuteItemFunction(ItemBehavior* this, u32 index);
 
 extern void ItemDebug(ItemBehavior*, u32);

--- a/include/script.h
+++ b/include/script.h
@@ -65,6 +65,6 @@ ScriptExecutionContext* CreateScriptExecutionContext(void);
 void InitScriptForEntity(Entity* entity, ScriptExecutionContext* context, Script* script);
 
 extern u32 ResolveCollisionLayer(struct Entity_*);
-extern void UpdateCollisionLayer(struct Entity_*);
+extern u32 UpdateCollisionLayer(struct Entity_*);
 
 #endif // SCRIPT_H

--- a/port/port_linked_stubs.c
+++ b/port/port_linked_stubs.c
@@ -32,6 +32,7 @@
 
 #include "port_entity_ctx.h"
 #include "port_gba_mem.h"
+#include "port_rom.h"
 #include "port_runtime_config.h"
 #include "port_widescreen.h"
 
@@ -157,15 +158,15 @@ u32 gFrameObjLists[50016];
 
 // gMapData — map data blob, backed by ROM data.
 // On GBA this is a label in .rodata at gAreaRoomMap_None (~14MB region).
-// On PC, we use a large buffer filled from ROM in Port_LoadRom().
-// Source files use &gMapData + offset, so this must be an array (not a pointer).
+// On PC it points into gRomData (set in Port_LoadRom()); source files only
+// compute gMapData + offset, so a pointer is sufficient and avoids a 14 MB copy.
 #ifdef TMC_N64
 /* #N64: the ~14 MB ROM map-data window can't live in 8 MB RDRAM. Temporary 1 MB
  * placeholder so the binary links and boots to the title (which doesn't read map
  * data). Phase 3 backs &gMapData with the embedded cart ROM (PI/DFS), not a RAM copy. */
 u8 gMapData[0x100000] __attribute__((aligned(4))); /* 1 MB placeholder */
 #else
-u8 gMapData[0xE00000] __attribute__((aligned(4))); /* ~14 MB */
+u8* gMapData = NULL;
 #endif
 
 // gCollisionMtx — On GBA, the collision matrix label sits at 0x080B7B74 with
@@ -1705,12 +1706,15 @@ u32 GetActTileRelativeToEntity(Entity* entity, s32 xOffset, s32 yOffset) {
  * tileType >= 0x4000 → gMapSpecialTileToActTile[tileType - 0x4000]
  */
 extern const u8 gMapTileTypeToActTile[];
-extern const u16 gUnk_080B7A3E[]; /* gMapSpecialTileToActTile */
+extern const u8 gMapSpecialTileToActTile[];
+extern const u16 gUnk_080B7A3E[];
 u32 GetActTileForTileType(u32 tileType) {
     if (tileType < 0x4000)
         return GetMapTileTypeToActTile(tileType);
     else
-        return ((const u8*)gUnk_080B7A3E)[tileType - 0x4000];
+        /* arm_GetActTileForTileType ldrb's gMapSpecialTileToActTile; gUnk_080B7A3E
+         * is the separate u16 special-tile property table (see sub_080B1B84). */
+        return gMapSpecialTileToActTile[tileType - 0x4000];
 }
 
 /* ---------- CollisionData family ---------- */
@@ -1841,7 +1845,9 @@ u32 sub_080B1B84(u32 tilePos, u32 layer) {
  * live on LAYER_TOP while the player walks on LAYER_BOTTOM, so the check
  * silently fails. If the queried layer returns 0 for the masked flag, fall
  * back to the OTHER layer — keeps existing behaviour when the property is
- * already present on the queried layer.
+ * already present on the queried layer. Only for the lantern mask 0x40:
+ * movement, roof priority, climbing and projectile masks must not borrow
+ * properties from a different collision layer.
  */
 u32 sub_080B1BA4(u32 tilePos, u32 layer, u32 mask) {
     u32 tileType = GetTileTypeAtTilePos(tilePos, layer);
@@ -1853,7 +1859,7 @@ u32 sub_080B1BA4(u32 tilePos, u32 layer, u32 mask) {
     }
     u32 r = table[tileType & 0x3FFF] & mask;
 #ifdef PC_PORT
-    if (r == 0) {
+    if (r == 0 && mask == 0x40) {
         u32 other = (layer == 2) ? 1 : 2;
         u32 tt2 = GetTileTypeAtTilePos(tilePos, other);
         const u16* t2 = (tt2 < 0x4000) ? (const u16*)&gRomData[0x360] : gUnk_080B7A3E;
@@ -1975,11 +1981,14 @@ void CloneTile(u32 tileType, u32 tilePos, u32 layer) {
 /**
  * Transition tile table entry for layer transitions.
  * (from ARM asm at 0x08016A90 / gTransitionTiles)
+ *
+ * preservedLayer: an entity already on this layer stays put; any other layer
+ * moves to destinationLayer.
  */
 typedef struct {
     u16 actTile;
-    u8 fromLayer;
-    u8 toLayer;
+    u8 preservedLayer;
+    u8 destinationLayer;
 } TransitionTileEntry;
 
 static const TransitionTileEntry sTransitionTiles[] = {
@@ -2012,7 +2021,7 @@ u32 ResolveCollisionLayer(Entity* entity) {
             const TransitionTileEntry* p = sResolveCollisionLayerTiles;
             while (p->actTile != 0) {
                 if (actTile == p->actTile) {
-                    newLayer = p->toLayer;
+                    newLayer = p->destinationLayer;
                     break;
                 }
                 p++;
@@ -2029,14 +2038,20 @@ u32 ResolveCollisionLayer(Entity* entity) {
  * (port of ARM asm at 0x08016A68)
  *
  * Returns the act tile at the entity's position (preserved in r0 in ARM code).
+ *
+ * Retail: `cmp r3, r5; beq not_found` — if the current layer equals byte 2 of
+ * the record the layer is preserved, otherwise byte 3 is written. Records
+ * 0x52/0x27/0x26 are {3,3}: they move an entity from layer 1/2 onto layer 3.
+ * With the comparison reversed (c8dfdb16d) those records could only ever fire
+ * for an entity already on layer 3, making them inert.
  */
 u32 CheckOnLayerTransition(Entity* entity) {
     u32 actTile = GetActTileAtEntity(entity);
     const TransitionTileEntry* p = sTransitionTiles;
     while (p->actTile != 0) {
         if (p->actTile == actTile) {
-            if (entity->collisionLayer == p->fromLayer) {
-                entity->collisionLayer = p->toLayer;
+            if (entity->collisionLayer != p->preservedLayer) {
+                entity->collisionLayer = p->destinationLayer;
             }
             return actTile;
         }
@@ -2048,10 +2063,14 @@ u32 CheckOnLayerTransition(Entity* entity) {
 /**
  * UpdateCollisionLayer — check layer transition and update sprite priority.
  * (port of ARM asm at 0x08016AB4)
+ *
+ * Returns the pre-transition act tile from CheckOnLayerTransition (the asm
+ * pushes r0 around UpdateSpriteForCollisionLayer and pops it back).
  */
-void UpdateCollisionLayer(Entity* entity) {
-    CheckOnLayerTransition(entity);
+u32 UpdateCollisionLayer(Entity* entity) {
+    u32 actTile = CheckOnLayerTransition(entity);
     UpdateSpriteForCollisionLayer(entity);
+    return actTile;
 }
 
 /**
@@ -2078,8 +2097,9 @@ u32 GetTileHazardType(Entity* entity) {
     if (entity->action == 0)
         return 0;
 
-    UpdateCollisionLayer(entity);
-    u32 actTile = GetActTileAtEntity(entity);
+    /* Classify the act tile CheckOnLayerTransition saw, not a re-read after the
+     * layer may have changed — at a boundary that reads a different floor. */
+    u32 actTile = UpdateCollisionLayer(entity);
 
     /* Check z position — if entity is in the air, no hazard */
     if ((s16)entity->z.HALF.HI < 0)

--- a/port/port_rom.c
+++ b/port/port_rom.c
@@ -1523,20 +1523,20 @@ void Port_LoadRom(const char* path) {
         Port_LoadOverlayDataFromConst(kOverlaySizeData, 240);
     }
 
-    /* gMapData — copy map data blob from ROM into the PC buffer.
-     * On GBA, gMapData is a ROM label; on PC it's a large u8 array.
-     * Source files compute &gMapData + offset, so we fill the buffer. */
+    /* gMapData — map data blob. On GBA a ROM label; on PC a pointer into the
+     * loaded ROM (no 14 MB copy). The expectedRomSize check above already
+     * guarantees mapDataBase < gRomSize for every known offset table. */
     {
-        extern u8 gMapData[];
         u32 mapDataSize = gRomSize - R->mapDataBase;
-        if (mapDataSize > 0xE00000u)
-            mapDataSize = 0xE00000u;
 #ifdef TMC_N64
         if (mapDataSize > 0x100000u)
             mapDataSize = 0x100000u; /* gMapData is a 1 MB placeholder on N64 */
-#endif
         memcpy(gMapData, &gRomData[R->mapDataBase], mapDataSize);
         fprintf(stderr, "gMapData loaded (%u bytes from ROM offset 0x%X).\n", mapDataSize, R->mapDataBase);
+#else
+        gMapData = &gRomData[R->mapDataBase];
+        fprintf(stderr, "gMapData mapped (%u bytes at ROM offset 0x%X).\n", mapDataSize, R->mapDataBase);
+#endif
     }
 
     /* ---- Area / room data tables (0x90 entries each) ---- */

--- a/port/port_rom.h
+++ b/port/port_rom.h
@@ -8,6 +8,15 @@
 extern u8* gRomData;
 extern u32 gRomSize;
 
+/* gMapData — the ~14 MB map/asset blob (gAreaRoomMap_None on GBA). Immutable
+ * ROM content, so on PC it is a pointer into gRomData set by Port_LoadRom()
+ * rather than a second copy. Readers only do gMapData + offset. */
+#ifdef TMC_N64
+extern u8 gMapData[];
+#else
+extern u8* gMapData;
+#endif
+
 #ifdef PC_PORT
 /*
  * Host-pointer plausibility guard. Same range logic as the inline check in

--- a/port/port_save.c
+++ b/port/port_save.c
@@ -39,6 +39,8 @@
  */
 
 #include "port_types.h"
+#include "region.h"
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -70,6 +72,10 @@ static int sSaveTxnDepth = 0;
  * logs once per failure burst instead of once per write. */
 static int sFlushFailedLast = 0;
 static int sEepromInited = 0;
+/* Existing malformed/wrong-region files are readable only as an unavailable
+ * EEPROM. Never let InitSaveData turn them into a fresh save implicitly. The
+ * user can still explicitly clear/switch the profile through the existing UI. */
+static int sEepromWriteBlocked = 0;
 static char sActivePath[SAVE_FILENAME_MAX] = DEFAULT_SAVE_FILENAME;
 /* 1 once the user has explicitly chosen a named profile (config.json), so the
  * per-region default below must NOT override their choice. 0 in the default
@@ -81,6 +87,9 @@ static int sExplicitProfile = 0;
 /* First 8-byte block of every initialized TMC save ("AGBZELDA:..."), in
  * game-RAM order and in on-disk (mGBA wire) order. Same in all regions. */
 #define EEPROM_SIG_RAM "AGBZELDA"
+/* Full 0x20-byte signature record (src/save.c sSignatureLong); USA vs EU/JP. */
+#define EEPROM_SIGNATURE_USA "AGBZELDA:THE MINISH CAP:ZELDA 5"
+#define EEPROM_SIGNATURE_EU_JP "AGBZELDA:THE MINISH CAP:ZELDA 3"
 
 /* Reverse each 8-byte block in place: converts between game-RAM order
  * (in-memory) and mGBA/VBA-M wire order (on-disk). Involution: applying
@@ -93,6 +102,146 @@ static void ReverseEepromBlocks(u8* buf) {
             buf[b + EEPROM_BLOCK - 1 - i] = t;
         }
     }
+}
+
+/* ---- Image classification ------------------------------------------------
+ * Decide what a candidate 8 KiB image is BEFORE the game sees it, so a file we
+ * can't prove is ours (short, oversized, garbage, another region's save) is
+ * never handed to InitSaveData as "blank" and then overwritten. */
+
+static int BufferIsAll(const u8* data, size_t size, u8 value) {
+    for (size_t i = 0; i < size; ++i)
+        if (data[i] != value)
+            return 0;
+    return 1;
+}
+
+/* 1 = USA signature, 2 = EU/JP signature, 0 = neither. */
+static int EepromSignatureKindAt(const u8* ramImage, u32 offset) {
+    if (memcmp(ramImage + offset, EEPROM_SIGNATURE_USA, 0x20) == 0)
+        return 1;
+    if (memcmp(ramImage + offset, EEPROM_SIGNATURE_EU_JP, 0x20) == 0)
+        return 2;
+    return 0;
+}
+
+static u16 ReadU16LE(const u8* data) {
+    return (u16)((u16)data[0] | ((u16)data[1] << 8));
+}
+
+static u32 ReadU32LE(const u8* data) {
+    return (u32)data[0] | ((u32)data[1] << 8) | ((u32)data[2] << 16) | ((u32)data[3] << 24);
+}
+
+/* Mirrors src/save.c CalculateChecksum over a byte image. */
+static u16 CalculateImageChecksum(const u8* data, u32 size) {
+    u32 checksum = 0;
+    while (size != 0) {
+        checksum += ReadU16LE(data) ^ size;
+        data += 2;
+        size -= 2;
+    }
+    return (u16)checksum;
+}
+
+/* A record is valid when either of its two SaveFileStatus copies is an
+ * untouched/deleted marker or an 'MCZ3' status whose checksum covers the data
+ * (src/save.c ReadSaveFileStatus + VerifyChecksum). */
+static int EepromStatusValidForData(const u8* ramImage, u32 statusOffset, u32 dataOffset, u32 dataSize) {
+    for (unsigned copy = 0; copy < 2; ++copy) {
+        const u8* statusBytes = ramImage + statusOffset + copy * 8u;
+        const u16 checksum1 = ReadU16LE(statusBytes);
+        const u16 checksum2 = ReadU16LE(statusBytes + 2);
+        const u32 status = ReadU32LE(statusBytes + 4);
+        if ((status == (u32)'TINI' || status == (u32)'FleD') && checksum1 == 0xFFFF && checksum2 == 0xFFFF)
+            return 1;
+        if (status == (u32)'MCZ3' && checksum2 == (u16)(-checksum1)) {
+            u16 expected = CalculateImageChecksum(statusBytes + 4, 4);
+            expected = (u16)(expected + CalculateImageChecksum(ramImage + dataOffset, dataSize));
+            if (checksum1 == expected)
+                return 1;
+        }
+    }
+    return 0;
+}
+
+/* Number of save records (3 slots, header, misc) with at least one valid
+ * status+data copy. Rows mirror src/save.c gSaveFileEEPROMAddresses. Retail
+ * reads each record independently, so one damaged slot must not hide the
+ * others. */
+static unsigned EepromValidRecordCount(const u8* ramImage) {
+    static const struct {
+        u16 size, status1, status2, data1, data2;
+    } records[] = {
+        { 0x500, 0x30, 0x1030, 0x80, 0x1080 },
+        { 0x500, 0x40, 0x1040, 0x580, 0x1580 },
+        { 0x500, 0x50, 0x1050, 0xA80, 0x1A80 },
+        { 0x10, 0x20, 0x1020, 0x70, 0x1070 },
+        { 0x20, 0x60, 0x1060, 0xF80, 0x1F80 },
+    };
+    unsigned validCount = 0;
+    for (size_t i = 0; i < sizeof(records) / sizeof(records[0]); ++i) {
+        if (EepromStatusValidForData(ramImage, records[i].status1, records[i].data1, records[i].size) ||
+            EepromStatusValidForData(ramImage, records[i].status2, records[i].data2, records[i].size))
+            ++validCount;
+    }
+    return validCount;
+}
+
+typedef enum {
+    EEPROM_IMAGE_INVALID = 0,
+    EEPROM_IMAGE_BLANK,
+    EEPROM_IMAGE_ACTIVE_REGION,
+    EEPROM_IMAGE_OTHER_REGION,
+} EepromImageClass;
+
+static EepromImageClass ClassifyRamEepromImage(const u8* ramImage) {
+    const int signature1 = EepromSignatureKindAt(ramImage, 0);
+    const int signature2 = EepromSignatureKindAt(ramImage, 0x1000);
+    const int activeSignature = (REGION_IS_EU || REGION_IS_JP) ? 2 : 1;
+
+    if (BufferIsAll(ramImage, EEPROM_SIZE, 0xFF))
+        return EEPROM_IMAGE_BLANK;
+    /* Two recognized but different region signatures cannot be repaired
+     * automatically: choosing either one would overwrite the other copy. */
+    if (signature1 != 0 && signature2 != 0 && signature1 != signature2)
+        return EEPROM_IMAGE_INVALID;
+    if (signature1 == activeSignature || signature2 == activeSignature) {
+        /* Require semantic evidence beyond the signature, but accept a partial
+         * image when any record still has a valid duplicated status/checksum. */
+        return EepromValidRecordCount(ramImage) != 0 ? EEPROM_IMAGE_ACTIVE_REGION : EEPROM_IMAGE_INVALID;
+    }
+    if (signature1 != 0 || signature2 != 0)
+        return EEPROM_IMAGE_OTHER_REGION;
+    return EEPROM_IMAGE_INVALID;
+}
+
+/* Load exactly one raw 8 KiB file into ramImage (game-RAM order on return)
+ * and select its byte order only when a known signature (or an all-FF blank
+ * image) proves the interpretation. *legacyRamOrder = 1 when the file was
+ * in legacy port (game-RAM) order and needs the byte-order migration. */
+static EepromImageClass ReadAndClassifyEepromFile(const char* path, u8* ramImage, int* legacyRamOrder) {
+    FILE* file = fopen(path, "rb");
+    if (file == NULL)
+        return EEPROM_IMAGE_INVALID;
+    const size_t got = fread(ramImage, 1, EEPROM_SIZE, file);
+    const int trailing = got == EEPROM_SIZE ? fgetc(file) : EOF;
+    const int readOk = !ferror(file);
+    const int closeOk = fclose(file) == 0;
+    if (got != EEPROM_SIZE || trailing != EOF || !readOk || !closeOk)
+        return EEPROM_IMAGE_INVALID;
+
+    *legacyRamOrder = 0;
+    EepromImageClass cls = ClassifyRamEepromImage(ramImage);
+    if (cls == EEPROM_IMAGE_ACTIVE_REGION || cls == EEPROM_IMAGE_OTHER_REGION) {
+        *legacyRamOrder = 1;
+        return cls;
+    }
+    if (cls == EEPROM_IMAGE_BLANK)
+        return cls;
+
+    ReverseEepromBlocks(ramImage);
+    return ClassifyRamEepromImage(ramImage);
 }
 
 /* Write the in-memory EEPROM to f in on-disk order. 1 on full write. */
@@ -187,24 +336,51 @@ static void ResolveRegionDefaultPath(void) {
 #endif
 
 static void LoadEepromFile(void) {
+    int legacyRamOrder = 0;
 #ifdef MULTI_REGION
     ResolveRegionDefaultPath();
 #endif
-    FILE* f = fopen(sActivePath, "rb");
-    if (!f) {
+    sEepromWriteBlocked = 0;
+    FILE* probe = fopen(sActivePath, "rb");
+    if (!probe) {
+        const int openError = errno;
         memset(sEeprom, 0xFF, EEPROM_SIZE); /* blank EEPROM = 0xFF */
-        fprintf(stderr, "[SAVE] No save file at %s, starting fresh.\n", sActivePath);
+        if (openError == ENOENT) {
+            fprintf(stderr, "[SAVE] No save file at %s, starting fresh.\n", sActivePath);
+        } else {
+            sEepromWriteBlocked = 1;
+            fprintf(stderr, "[SAVE] ERROR: cannot read %s; writes are disabled and the file is untouched.\n",
+                    sActivePath);
+        }
         return;
     }
-    const size_t got = fread(sEeprom, 1, EEPROM_SIZE, f);
-    fclose(f);
-    if (got != EEPROM_SIZE) {
-        fprintf(stderr, "[SAVE] ERROR: short read on %s (%zu/%d bytes), starting fresh.\n", sActivePath, got,
-                EEPROM_SIZE);
-        memset(sEeprom, 0xFF, EEPROM_SIZE); /* blank EEPROM = 0xFF */
+    fclose(probe);
+
+    switch (ReadAndClassifyEepromFile(sActivePath, sEeprom, &legacyRamOrder)) {
+    case EEPROM_IMAGE_INVALID:
+        memset(sEeprom, 0xFF, EEPROM_SIZE);
+        sEepromWriteBlocked = 1;
+        fprintf(stderr,
+                "[SAVE] ERROR: %s is not one exact, recognized 8 KiB EEPROM image; writes are disabled and the "
+                "file is untouched.\n",
+                sActivePath);
         return;
+    case EEPROM_IMAGE_OTHER_REGION:
+        memset(sEeprom, 0xFF, EEPROM_SIZE);
+        sEepromWriteBlocked = 1;
+        fprintf(stderr,
+                "[SAVE] ERROR: %s belongs to another ROM region; writes are disabled so InitSaveData cannot erase "
+                "it.\n",
+                sActivePath);
+        return;
+    case EEPROM_IMAGE_BLANK:
+        fprintf(stderr, "[SAVE] Loaded blank EEPROM image: %s\n", sActivePath);
+        return;
+    case EEPROM_IMAGE_ACTIVE_REGION:
+        break;
     }
-    if (memcmp(sEeprom, EEPROM_SIG_RAM, EEPROM_BLOCK) == 0) {
+
+    if (legacyRamOrder) {
         /* Legacy port-format file (game-RAM order on disk). The buffer
          * is already in the order we keep in memory; keep the original
          * bytes as .bak, then rewrite the file in on-disk order. */
@@ -221,9 +397,8 @@ static void LoadEepromFile(void) {
         sEepromDirty = 1;
         FlushEepromFile();
     } else {
-        /* mGBA/VBA-M order — or blank/uninitialized, where reversal is
-         * inconsequential. Convert to game-RAM order in memory. */
-        ReverseEepromBlocks(sEeprom);
+        /* ReadAndClassifyEepromFile already converted mGBA/VBA-M order to
+         * game-RAM order after validating the active-region signature. */
         fprintf(stderr, "[SAVE] Loaded save file: %s\n", sActivePath);
     }
 }
@@ -258,13 +433,15 @@ void Port_Save_BeginTransaction(void) {
     sSaveTxnDepth++;
 }
 
-/* Returns 1 when everything the transaction wrote is durably on disk. */
+/* Returns 1 when everything the transaction wrote is durably on disk. A
+ * write-blocked profile never reports success: the game must show the
+ * save-failed path instead of believing a save it could not make. */
 int Port_Save_EndTransaction(void) {
     if (sSaveTxnDepth > 0)
         sSaveTxnDepth--;
     if (sSaveTxnDepth == 0)
         FlushEepromFile();
-    return !sEepromDirty;
+    return !sEepromWriteBlocked && !sEepromDirty;
 }
 
 /* ---- EEPROM BIOS API ---------------------------------------------------- */
@@ -298,6 +475,8 @@ u16 EEPROMWrite0_8k_Check(u16 block, const u16* src) {
     }
     if (block >= EEPROM_BLOCKS)
         return 0x80FF; /* EEPROM_OUT_OF_RANGE */
+    if (sEepromWriteBlocked)
+        return 0x8000; /* preserve malformed/wrong-region backing file */
 
     memcpy(&sEeprom[block * EEPROM_BLOCK], src, EEPROM_BLOCK);
     sEepromDirty = 1;
@@ -353,6 +532,7 @@ void Port_Save_SetActivePath(const char* path) {
      * the new file. */
     sEepromInited = 0;
     sEepromDirty = 0;
+    sEepromWriteBlocked = 0;
 }
 
 const char* Port_Save_GetActivePath(void) {

--- a/port/port_script_funcs.c
+++ b/port/port_script_funcs.c
@@ -187,6 +187,9 @@ extern void sub_08053B3C();
 extern void sub_08053BE8();
 extern void sub_08053C84();
 extern void sub_08054968();
+extern void sub_08054EB8();
+extern void sub_08054EFC();
+extern void sub_08054F64();
 extern void sub_0806014C();
 extern void sub_08060158();
 extern void sub_08060208();
@@ -536,6 +539,11 @@ static const ScriptFuncEntry sScriptFuncTable[] = {
     { 0x08054565, (void (*)(void))DisableRandomDrops },
     { 0x08054571, (void (*)(void))EnableRandomDrops },
     { 0x08054969, (void (*)(void))sub_08054968 },
+    /* HAND-FIX (keep on regenerate): Goron Kinstone wall/sync callbacks
+     * (worldEvent17.c) called from script_GoronKinstone / Goron2Kinstone*. */
+    { 0x08054EB9, (void (*)(void))sub_08054EB8 },
+    { 0x08054EFD, (void (*)(void))sub_08054EFC },
+    { 0x08054F65, (void (*)(void))sub_08054F64 },
     { 0x0805DDED, (void (*)(void))CreateRepeatedSoundManager },
     { 0x0805DE19, (void (*)(void))DeleteRepeatedSoundManager },
     { 0x0805E545, (void (*)(void))SetPlayerEventPriority },
@@ -1026,6 +1034,10 @@ static const ScriptFuncEntry sScriptFuncTable_EU[] = {
     { 0x080540FD, (void (*)(void))DisableRandomDrops },
     { 0x08054109, (void (*)(void))EnableRandomDrops },
     { 0x080544E9, (void (*)(void))sub_08054968 },
+    /* HAND-FIX (keep on regenerate): Goron Kinstone callbacks, eu.map. */
+    { 0x08054A39, (void (*)(void))sub_08054EB8 },
+    { 0x08054A7D, (void (*)(void))sub_08054EFC },
+    { 0x08054AE5, (void (*)(void))sub_08054F64 },
     { 0x0805D889, (void (*)(void))CreateRepeatedSoundManager },
     { 0x0805D8B5, (void (*)(void))DeleteRepeatedSoundManager },
     { 0x0805DFCD, (void (*)(void))SetPlayerEventPriority },
@@ -1499,6 +1511,10 @@ static const ScriptFuncEntry sScriptFuncTable_JP[] = {
     { 0x080543E9, (void (*)(void))DisableRandomDrops },
     { 0x080543F5, (void (*)(void))EnableRandomDrops },
     { 0x080547ED, (void (*)(void))sub_08054968 },
+    /* HAND-FIX (keep on regenerate): Goron Kinstone callbacks, jp.map. */
+    { 0x08054D3D, (void (*)(void))sub_08054EB8 },
+    { 0x08054D81, (void (*)(void))sub_08054EFC },
+    { 0x08054DE9, (void (*)(void))sub_08054F64 },
     { 0x0805DC41, (void (*)(void))CreateRepeatedSoundManager },
     { 0x0805DC6D, (void (*)(void))DeleteRepeatedSoundManager },
     { 0x0805E385, (void (*)(void))SetPlayerEventPriority },

--- a/src/beanstalkSubtask.c
+++ b/src/beanstalkSubtask.c
@@ -28,7 +28,9 @@ extern void LoadRoomGfx(void);
 extern void LoadRoomTileSet(void);
 extern void sub_0807C4F8(void);
 
-extern u8 gMapData[];
+#ifndef PC_PORT
+extern u8 gMapData[]; /* PC: u8* declared in port_rom.h */
+#endif
 extern u8 gUpdateVisibleTiles;
 extern u16 MAY_ALIAS gMapDataTopSpecial[];
 extern u16 MAY_ALIAS gMapDataBottomSpecial[];

--- a/src/common.c
+++ b/src/common.c
@@ -103,7 +103,9 @@ void SortKinstoneBag(void);
 
 extern void* GetRoomProperty(u32, u32, u32);
 
-extern u8 gMapData[];
+#ifndef PC_PORT
+extern u8 gMapData[]; /* PC: u8* declared in port_rom.h */
+#endif
 extern const DungeonLayout* const* const gDungeonLayouts[];
 extern u16 gMapDataBottomSpecial[];
 

--- a/src/data/data_080046A4.c
+++ b/src/data/data_080046A4.c
@@ -11,8 +11,8 @@ const KeyValuePair gUnk_080046A4[] = {
     { 42, 36 },    { 29, 36 },  { 43, 36 },  { 97, 44 },  { 101, 45 }, { 353, 47 }, { 355, 48 }, { 16384, 25 },
     { 16480, 26 }, { 374, 49 }, { 843, 33 }, { 844, 34 }, { 375, 50 }, { 871, 51 }, { 872, 52 }, { 16490, 24 },
     { 105, 41 },   { 106, 42 }, { 111, 43 }, { 109, 53 }, { 110, 54 }, { 78, 7 },   { 389, 36 }, { 390, 36 },
-    { 345, 66 },   { 346, 67 }, { 179, 68 }, { 344, 65 }, { 167, 3 },  { 168, 64 }, { 334, 53 }, { 266, 60 },
-    { 0, 0 }
+    { 391, 36 },   { 392, 36 }, { 393, 36 }, { 394, 36 }, { 398, 36 }, { 399, 36 }, { 403, 36 }, { 404, 36 },
+    { 405, 36 },   { 406, 36 }, { 407, 36 }, { 408, 36 }, { 0, 0 }
 };
 const u16 gUnk_080046A4End = 0;
 
@@ -257,49 +257,6 @@ const u16 gUnk_080047F6[] = {
     30,
     1,
     49152,
-#ifdef PC_PORT
-    /* Rows 60..68: gUnk_080046A4 maps tiles 266,168,344,345,346,179 to values
-     * 60..68, which index PAST the 60 rows above. On GBA those reads landed in
-     * the player-macro data that follows at 0x080049D6 and returned stable
-     * bytes; on PC the linker decides what's there instead. Append those ROM
-     * bytes verbatim so the out-of-table tiles keep GBA-identical flags. */
-    4,
-    32,
-    1,
-    128,
-    60,
-    1,
-    1,
-    32,
-    60,
-    1,
-    1,
-    16,
-    60,
-    1,
-    16384,
-    65532,
-    0,
-    1,
-    16384,
-    65532,
-    1,
-    64,
-    120,
-    2,
-    60,
-    0,
-    49152,
-    120,
-    2,
-    60,
-    0,
-    49152,
-    60,
-    16,
-    4,
-    2,
-#endif
 };
 
 #define PLAYER_MACRO_JUMPTO 0x4000 // Jump

--- a/src/enemyUpdate.c
+++ b/src/enemyUpdate.c
@@ -120,6 +120,13 @@ extern u32 GetFacingDirection(Entity*, Entity*);
 
 u32 sub_0800132C(Entity* entity, Entity* target) {
     s32 dx, dy;
+#ifdef PC_PORT
+    /* Enemy targets are temporarily cleared while the player is removed
+     * during some room/hazard transitions; a Leever can still be scheduled
+     * that frame, so treat a missing target as "no direction". */
+    if (entity == NULL || target == NULL)
+        return 0xFF;
+#endif
     if (!(entity->collisionLayer & target->collisionLayer))
         return 0xFF;
     dx = entity->x.HALF.HI - target->x.HALF.HI + 8;

--- a/src/manager/delayedEntityLoadManager.c
+++ b/src/manager/delayedEntityLoadManager.c
@@ -96,7 +96,18 @@ void DelayedEntityLoadManager_Main(DelayedEntityLoadManager* this) {
     while (npcPtr2->id != 0xff) {
         if (!CheckRectOnScreen(npcPtr2->x, npcPtr2->y, 0x18, 0x20)) {
             ClearBit(bitfield, index2);
-        } else if ((npcPtr2->progressBitfield & progressMask) && gEntCount < 0x47 && !WriteBit(bitfield, index2) &&
+        } else if ((npcPtr2->progressBitfield & progressMask) && gEntCount < 0x47 &&
+#ifdef PC_PORT
+                   /* Publish the spawn bit only once the script context and
+                    * entity both exist (WriteBit below). With WriteBit here
+                    * and all 32 script contexts busy, the entity was never
+                    * created but its slot stayed marked as spawned until it
+                    * left the viewport, permanently hiding scripted escape
+                    * objects such as the Cloud Tops whirlwinds. */
+                   !ReadBit(bitfield, index2) &&
+#else
+                   !WriteBit(bitfield, index2) &&
+#endif
                    (npcPtr2->script == NULL || (context = CreateScriptExecutionContext(), context != NULL))) {
             if (super->timer == 0) {
                 entity = CreateNPC(npcPtr2->id, npcPtr2->type, npcPtr2->type2);
@@ -104,6 +115,9 @@ void DelayedEntityLoadManager_Main(DelayedEntityLoadManager* this) {
                 entity = CreateObject(npcPtr2->id, npcPtr2->type, npcPtr2->type2);
             }
             if (entity != NULL) {
+#ifdef PC_PORT
+                WriteBit(bitfield, index2);
+#endif
                 tmp = this->unk_20 + 1;
                 entity->health = index2 + tmp;
                 entity->timer = npcPtr2->timer;

--- a/src/manager/fallingItemManager.c
+++ b/src/manager/fallingItemManager.c
@@ -28,6 +28,7 @@ void FallingItemManager_Init(FallingItemManager* this) {
     super->action = 1;
     if (CheckFlags(this->field_0x3c)) {
         DeleteThisEntity();
+        return;
     }
     FallingItemManager_Action1(this);
 }
@@ -41,7 +42,9 @@ void FallingItemManager_Action1(FallingItemManager* this) {
             object->base.x.HALF.HI = this->field_0x38 + gRoomControls.origin_x;
             object->base.y.HALF.HI = this->field_0x3a + gRoomControls.origin_y;
             object->flag = this->field_0x3c;
+            DeleteThisEntity();
         }
-        DeleteThisEntity();
+        /* CreateObject failed: keep the manager alive and retry next frame
+         * instead of silently dropping the item. */
     }
 }

--- a/src/manager/horizontalMinishPathBackgroundManager.c
+++ b/src/manager/horizontalMinishPathBackgroundManager.c
@@ -97,14 +97,26 @@ void sub_08058034(void) {
     u32 tmp;
     u16 *tmp2, *tmp3;
     tmp2 = gMapDataTopSpecial;
+#ifdef PC_PORT
+    /* On GBA gUnk_02006F00 immediately follows gMapDataTopSpecial in EWRAM
+     * (0x02002F00 + 0x4000), so `gMapDataTopSpecial + 0x2000` (u16) lands in
+     * gUnk_02006F00 — the buffer sub_08058004 reads. PC has separate arrays;
+     * write the alias explicitly. */
+    tmp3 = (u16*)gUnk_02006F00;
+#else
     tmp3 = gMapDataTopSpecial + 0x2000;
+#endif
     for (tmp = 0; tmp < 4; tmp++) {
         sub_08058084(tmp2, tmp3);
         tmp2 += 0x400;
         tmp3 += 0x20;
     }
     tmp2 = gMapDataTopSpecial + 0x1000;
+#ifdef PC_PORT
+    tmp3 = (u16*)(gUnk_02006F00 + 0x2000);
+#else
     tmp3 = gMapDataTopSpecial + 0x3000;
+#endif
     for (tmp = 0; tmp < 4; tmp++) {
         sub_08058084(tmp2, tmp3);
         tmp2 += 0x400;

--- a/src/npc/npc5.c
+++ b/src/npc/npc5.c
@@ -104,7 +104,7 @@ u32 PointInsideRadius(s32, s32, s32);
 
 u32 CalcJumpDirection(Entity*);
 extern u32 sub_08079FD4(Entity*, u32);
-extern void UpdateCollisionLayer(Entity*);
+extern u32 UpdateCollisionLayer(Entity*);
 
 bool32 TryNavRightFromAbove(NPC5Entity*, s32, s32, s32);
 bool32 TryNavUpFromRight(NPC5Entity*, s32, s32, s32);

--- a/src/object/itemOnGround.c
+++ b/src/object/itemOnGround.c
@@ -373,7 +373,13 @@ void ItemOnGround_SetFlagAndDelete(ItemOnGroundEntity* this, bool32 doSetFlag) {
     DeleteThisEntity();
 }
 
-bool32 sub_08081420(ItemOnGroundEntity* this) {
+enum ItemOnGroundAwardResult {
+    ITEM_AWARD_DIRECT,
+    ITEM_AWARD_CUTSCENE,
+    ITEM_AWARD_RETRY,
+};
+
+u32 sub_08081420(ItemOnGroundEntity* this) {
 #ifdef PC_PORT
     /* Resolve the per-location randomized reward BEFORE the item-get-cutscene
      * decision: the GBA randomizer rewrites the item bytes in the room's entity
@@ -401,12 +407,14 @@ bool32 sub_08081420(ItemOnGroundEntity* this) {
     if (CheckShouldPlayItemGetCutscene(this)) {
         u8 item = (u8)super->type;
         u8 subtype = (u8)super->type2;
+        if (!CreateItemEntityWithFlag(item, subtype, 0, this->flag)) {
+            return ITEM_AWARD_RETRY;
+        }
         SetEntityPriority(super, PRIO_PLAYER_EVENT);
-        CreateItemEntity(item, subtype, 0);
-        return TRUE;
+        return ITEM_AWARD_CUTSCENE;
     } else {
         GiveItem(super->type, super->type2);
-        return FALSE;
+        return ITEM_AWARD_DIRECT;
     }
 }
 
@@ -502,8 +510,21 @@ void sub_0808153C(ItemOnGroundEntity* this) {
 }
 
 void sub_08081598(ItemOnGroundEntity* this) {
+    u32 awardResult = ITEM_AWARD_DIRECT;
+
     if (super->health == 0) {
         ItemOnGround_SetFlagAndDelete(this, 1);
+        return;
+    }
+
+    if (super->type != 0x5F) {
+        awardResult = sub_08081420(this);
+        if (awardResult == ITEM_AWARD_RETRY) {
+            /* The item-get cutscene needs both aux entity slots. Keep the
+             * pickup intact and collidable so a later frame can retry;
+             * setting the location flag first would lose the item. */
+            return;
+        }
     }
 
     COLLISION_OFF(super);
@@ -516,7 +537,9 @@ void sub_08081598(ItemOnGroundEntity* this) {
     super->child = &gPlayerEntity.base;
     CopyPosition(super->child, super);
     super->z.HALF.HI -= 4;
-    if (super->type != 0x5F && sub_08081420(this)) {
-        ItemOnGround_SetFlagAndDelete(this, 1);
+    if (awardResult == ITEM_AWARD_CUTSCENE) {
+        /* LinkHoldingItem owns the location flag now and commits it only
+         * after GiveItem() has actually changed the save. */
+        ItemOnGround_SetFlagAndDelete(this, 0);
     }
 }

--- a/src/object/linkHoldingItem.c
+++ b/src/object/linkHoldingItem.c
@@ -5,6 +5,7 @@
  * @brief Link Holding Item object
  */
 #include "scroll.h"
+#include "flags.h"
 #include "game.h"
 #include "item.h"
 #include "itemMetaData.h"
@@ -17,6 +18,7 @@
 typedef struct {
     /*0x00*/ Entity base;
     /*0x68*/ u16 unk_68;
+    /*0x6a*/ u16 completionFlag; /**< Location flag to set once GiveItem ran (0 = none). */
 } LinkHoldingItemEntity;
 
 void LinkHoldingItem_Init(LinkHoldingItemEntity*);
@@ -55,6 +57,10 @@ void LinkHoldingItem_Action1(LinkHoldingItemEntity* this) {
         case 0:
         case 1:
             this->unk_68 = GiveItem(super->type, super->type2);
+            if (this->completionFlag != 0) {
+                SetFlag(this->completionFlag);
+                this->completionFlag = 0;
+            }
             switch (super->type) {
                 case ITEM_EARTH_ELEMENT:
                 case ITEM_FIRE_ELEMENT:
@@ -68,6 +74,10 @@ void LinkHoldingItem_Action1(LinkHoldingItemEntity* this) {
             break;
         case 2:
             GiveItem(super->type, super->type2);
+            if (this->completionFlag != 0) {
+                SetFlag(this->completionFlag);
+                this->completionFlag = 0;
+            }
 #ifdef MULTI_REGION
             this->unk_68 = (REGION_IS_EU ? gUnk_080FD964_eu : gUnk_080FD964)[super->type].gotItemMessageId;
 #else

--- a/src/object/pot.c
+++ b/src/object/pot.c
@@ -78,7 +78,7 @@ void sub_080826FC(PotEntity* this);
 static bool32 Pot_HasJarContact(PotEntity* this);
 
 extern void RegisterCarryEntity(Entity*);
-extern void CheckOnLayerTransition(Entity*);
+extern u32 CheckOnLayerTransition(Entity*);
 
 void Pot(PotEntity* this) {
     static void (*const Pot_Actions[])(PotEntity*) = {

--- a/src/object/pullableMushroom.c
+++ b/src/object/pullableMushroom.c
@@ -309,9 +309,13 @@ void sub_0808AEB0(PullableMushroomEntity* this) {
         COLLISION_OFF(super);
         super->spriteSettings.flipX = gPlayerEntity.base.spriteSettings.flipX;
         InitializeAnimation(super, super->animationState + 5);
-        if (sub_0808B21C(this, 0)) {
-            sub_0808B168((PullableMushroomEntity*)super->child, 0);
+        if (!sub_0808B21C(this, 0)) {
+            /* Entity pressure: abort this pull through the release state.
+             * Advancing with no child would dereference NULL next frame. */
+            super->subAction = 6;
+            return;
         }
+        sub_0808B168((PullableMushroomEntity*)super->child, 0);
         if ((super->animationState & 1) != 0) {
             gPlayerEntity.base.y.HALF.HI = super->y.HALF.HI;
         } else {
@@ -359,9 +363,12 @@ void sub_0808B05C(PullableMushroomEntity* this) {
         super->spriteSettings.flipX = gPlayerEntity.base.spriteSettings.flipX;
         COLLISION_OFF(super);
         InitializeAnimation(super, super->animationState + 5);
-        if (sub_0808B21C(this, 1)) {
-            sub_0808B168((PullableMushroomEntity*)super->child, 1);
+        if (!sub_0808B21C(this, 1)) {
+            /* Stay in setup and retry once entity slots free up;
+             * sub_0808B21C leaves no half-linked child/affine behind. */
+            return;
         }
+        sub_0808B168((PullableMushroomEntity*)super->child, 1);
     }
     super->subAction++;
 }
@@ -454,24 +461,32 @@ u32 sub_0808B1F0(PullableMushroomEntity* this, Entity* other) {
 }
 
 bool32 sub_0808B21C(PullableMushroomEntity* this, u32 param_2) {
-    Entity* obj;
+    Entity* child;
+    Entity* affine;
+
+    /* The stretching cap and its affine helper must either both exist or
+     * neither be published through the parent pointers; assigning each
+     * immediately left later states with NULL/half-linked entities. */
+    child = CreateObjectWithParent(super, PULLABLE_MUSHROOM, 1, 0);
+    if (child == NULL) {
+        return FALSE;
+    }
+    affine = CreateObjectWithParent(super, PULLABLE_MUSHROOM, 2, 0);
+    if (affine == NULL) {
+        DeleteEntity(child);
+        return FALSE;
+    }
+
+    child->animationState = super->animationState;
+    child->direction = super->direction;
+    child->spriteSettings.flipX = super->spriteSettings.flipX;
+    child->parent = super;
+    child->type2 = (u8)param_2;
+    affine->animationState = super->animationState;
+    affine->child = child;
 
     super->spritePriority.b0 = 6;
-    obj = CreateObjectWithParent(super, PULLABLE_MUSHROOM, 1, 0);
-    super->child = obj;
-    if (obj != NULL) {
-        obj->animationState = super->animationState;
-        (super->child)->direction = super->direction;
-        super->child->spriteSettings.flipX = super->spriteSettings.flipX;
-        (super->child)->parent = super;
-        (super->child)->type2 = (u8)param_2;
-    }
-    obj = CreateObjectWithParent(super, PULLABLE_MUSHROOM, 2, 0);
-    super->parent = obj;
-    if (obj != NULL) {
-        obj->animationState = super->animationState;
-        (super->parent)->child = super->child;
-        return TRUE;
-    }
-    return FALSE;
+    super->child = child;
+    super->parent = affine;
+    return TRUE;
 }

--- a/src/playerItemUtils.c
+++ b/src/playerItemUtils.c
@@ -15,10 +15,24 @@ static void InitTileMessage(u32, u32);
 void SetPlayerItemGetState(Entity*, u8, u8);
 
 void CreateItemEntity(u32 type, u32 type2, u32 delay) {
+    CreateItemEntityWithFlag(type, type2, delay, 0);
+}
+
+/* Item-get cutscene needs both aux entities. Fails (creating nothing) if
+ * either allocation fails so the caller can keep its pickup and retry;
+ * completionFlag is committed by LinkHoldingItem only after GiveItem. */
+bool32 CreateItemEntityWithFlag(u32 type, u32 type2, u32 delay, u16 completionFlag) {
     Entity* e = GiveItemWithCutscene(type, type2, delay);
-    if (e != NULL) {
-        e->parent = CreateLinkAnimation(e, e->type, 0);
+    if (e == NULL) {
+        return FALSE;
     }
+    e->parent = CreateLinkAnimation(e, e->type, 0);
+    if (e->parent == NULL) {
+        DeleteEntity(e);
+        return FALSE;
+    }
+    ((GenericEntity*)e)->field_0x6a.HWORD = completionFlag;
+    return TRUE;
 }
 
 void InitItemGetSequence(u32 type, u32 type2, u32 delay) {

--- a/src/playerUtils.c
+++ b/src/playerUtils.c
@@ -52,7 +52,9 @@ extern void UpdateScreenShake(void);
 void sub_080790E4(Entity* this);
 void sub_08079064(Entity*);
 
-extern u8 gMapData[];
+#ifndef PC_PORT
+extern u8 gMapData[]; /* PC: u8* declared in port_rom.h */
+#endif
 extern const u8 gUnk_0800851C[];
 extern const u8 gUnk_080084BC[];
 extern const u8 gUnk_0800845C[];

--- a/src/projectile/spikedRollers.c
+++ b/src/projectile/spikedRollers.c
@@ -67,7 +67,10 @@ void SpikedRollers_Action1(SpikedRollersEntity* this) {
         unk_0x6c = -unk_0x6c;
     }
 
-    if ((u32)(diff << 0x10) > (unk_0x6c << 0x10)) {
+    /* diff is deliberately negative on a negative-travel roller's first
+     * frame; shift as unsigned to reproduce the ARM `lsls` wraparound
+     * without signed-shift UB under an optimizing host compiler. */
+    if (((u32)diff << 0x10) > ((u32)unk_0x6c << 0x10)) {
         super->direction ^= 0x10;
         if (super->type2 == 0) {
             super->x.HALF.HI = this->x2;

--- a/src/text.c
+++ b/src/text.c
@@ -69,6 +69,30 @@ extern u8* gTextVariableSources[];
 extern u8* gUnk_08109230[];
 #define gTextVariableSources gUnk_08109230
 #endif
+
+#ifdef PC_PORT
+/* On GBA gTextVariableSources[0] (0x020227DC) aliases gTextRender.player_name,
+ * which MsgInit fills. The port's globals are separate allocations, so
+ * ShowTextBox callers (both figurine-name screens) expanded {Player} to an
+ * empty string. Format the name into the slot the same way MsgInit does. */
+static void SyncInlineTextPlayerName(void) {
+    u8* dest = gTextVariableSources[0];
+    u32 i;
+
+    if (dest == NULL) {
+        return;
+    }
+    dest[0] = 2;
+    dest[1] = 0xe; // Green text color
+    dest += 2;
+    for (i = 0; i < FILENAME_LENGTH && gSave.name[i] != '\0'; ++i) {
+        *dest++ = gSave.name[i];
+    }
+    dest[0] = 2;
+    dest[1] = 0xf; // White text color
+    dest[2] = '\0';
+}
+#endif
 extern u32 gUnk_08109244; // TODO structure?
 extern u32* gUnk_08109248[];
 extern u32 gUnk_0810926C[];
@@ -576,6 +600,9 @@ u32 ShowTextBox(uintptr_t textIndexOrPtr, const Font* paramFont) {
     u32 temp2;
     u32 temp3;
 
+#ifdef PC_PORT
+    SyncInlineTextPlayerName();
+#endif
     pWVar4 = sub_0805F2C8();
     if (pWVar4 != NULL) {
 #ifdef PC_PORT


### PR DESCRIPTION
Ports the verified subset of [EstebanPdN/zelda-tmc-3ds](https://github.com/EstebanPdN/zelda-tmc-3ds) (GPL-3.0, branched from our v0.8.3) onto master. Each fix re-derived against master's current code; 3DS-specific infrastructure (Full View, PICA200, `TMC_3DS`, second screen, save-layout heuristics) left behind.

Engine:
- data_080046A4: restore the 12 upstream tile-property rows {391..408,36}
  that 79cf18395 replaced with 8 bogus pairs (and drop 7ab12c7d6's padding,
  which only existed to cover the out-of-range rows)
- horizontalMinishPathBackgroundManager: leaf tilemap written to
  gMapDataTopSpecial+0x2000, which on GBA aliases gUnk_02006F00 — the PC
  readers read a buffer nothing ever wrote, so the leaves never drew
- text: {Player} expanded empty in figurine-name text (gTextVariableSources[0]
  aliases gTextRender.player_name on GBA; nothing wrote it on PC)
- entity-pressure guards: delayed-entity spawn bit published before the script
  context existed (Cloud Tops whirlwind), pullable mushroom published child
  and affine pointers before both allocations succeeded, NULL target deref in
  sub_0800132C, UB negative shift in spikedRollers
- item-get: the location flag was set before the cutscene entities were
  allocated, so a failed allocation consumed the item; the flag now rides on
  the LinkHoldingItem entity and is committed after GiveItem

Port layer:
- CheckOnLayerTransition: comparison was reversed by c8dfdb16d. asm/src/script.s
  (0x08016A68) branches away when the layer EQUALS byte 2, so equal preserves
  and anything else moves to byte 3 — with '==' the {0x52,0x27,0x26} layer-3
  records could only fire for an entity already on layer 3, i.e. never
- UpdateCollisionLayer returns the pre-transition act tile (the asm pushes r0
  across UpdateSpriteForCollisionLayer); GetTileHazardType classifies that
  instead of re-reading the tile after the layer changed
- GetActTileForTileType: special tiles index gMapSpecialTileToActTile, not the
  u16 property table gUnk_080B7A3E read as bytes
- sub_080B1BA4 other-layer fallback narrowed to the lantern mask 0x40
- register the Goron Kinstone script callbacks sub_08054EB8/EFC/F64 (USA/EU/JP)
- port_save: a truncated, oversized, unrecognised or other-region .sav is no
  longer reformatted by InitSaveData — writes are blocked and the file is left
  untouched
- gMapData points into the loaded ROM instead of a 14 MB memcpy

## Verification
- Full `tmc_pc` build clean (USA baseline, multi-region, gpu_renderer).
- `TMC_ROOMCAP` bootstraps a new game and renders Minish Woods correctly on **both USA and EU** ROMs — exercises `gMapData` as a ROM pointer and the collision-layer changes in a live room.
- `TMC_REPRO_ITEMGET` runs the item-get cutscene to completion, no regression.
- port_save guard proven with a scoped harness: 100-byte, 8193-byte, garbage and EU-signature-under-USA files all return `0x8000` and are left **byte-for-byte untouched**; the same EU file under `gActiveRegion=EU` writes fine; blank/legacy-order images still migrate.
- `CheckOnLayerTransition` direction confirmed against `asm/src/script.s` in this repo (`cmp r3,r5; beq not_found`), not just the fork's audit doc.
- `gUnk_080047F6` bounds re-checked after dropping the padding: 240 entries, max index reached 219.
- Item-flag commit path checked: the `ItemOnGround` cutscene always passes `delay = 0`, so `LinkHoldingItem_Action1` hits `case 0` and sets the flag immediately after `GiveItem`.

## Not included (from the same fork)
The ~21 EU regional ROM tables still pinned to USA offsets (tile properties, collision masks, OBJ size table, sprite index hole at 288 → Gyorg sprites, USA blobs read on EU) and the `SaveFile` layout byte at 0x25B — both are larger pieces of work tracked separately.